### PR TITLE
feat(data): add related fields to all 259 points and fix equipment typical_points

### DIFF
--- a/data/equipment/air-handling.yaml
+++ b/data/equipment/air-handling.yaml
@@ -61,16 +61,19 @@ equipment:
       - supply-air-temperature
       - return-air-temperature
       - mixed-air-temperature
-      - outside-air-temperature
+      - outdoor-air-temperature
       - discharge-air-temperature
       - outside-air-damper-output
-      - return-air-damper-output
       - mixed-air-damper-output
       - cooling-valve-output
       - heating-valve-output
       - filter-alarm
       - low-limit-alarm
       - smoke-alarm
+      - discharge-air-temperature-setpoint
+      - duct-static-pressure
+      - duct-static-pressure-setpoint
+      - filter-differential-pressure
   - id: rooftop-unit
     name: Rooftop Unit
     abbreviation: RTU
@@ -136,7 +139,7 @@ equipment:
       - supply-air-temperature
       - return-air-temperature
       - mixed-air-temperature
-      - outside-air-temperature
+      - outdoor-air-temperature
       - discharge-air-temperature
       - outside-air-damper-output
       - cooling-valve-output
@@ -145,6 +148,8 @@ equipment:
       - gas-fired-heat-output
       - filter-alarm
       - economizer-enable
+      - filter-differential-pressure
+      - duct-static-pressure
   - id: makeup-air-unit
     name: Makeup Air Unit
     abbreviation: MAU
@@ -209,7 +214,7 @@ equipment:
       - supply-fan-speed
       - supply-air-temperature
       - discharge-air-temperature
-      - outside-air-temperature
+      - outdoor-air-temperature
       - heating-valve-output
       - gas-fired-heat-output
       - filter-alarm
@@ -261,7 +266,7 @@ equipment:
       - supply-fan-status
       - supply-fan-speed
       - supply-air-temperature
-      - outside-air-temperature
+      - outdoor-air-temperature
       - discharge-air-temperature
       - cooling-valve-output
       - heating-valve-output
@@ -337,8 +342,8 @@ equipment:
       - zone-temperature
       - cooling-valve-output
       - heating-valve-output
-      - cooling-setpoint
-      - heating-setpoint
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: computer-room-air-conditioner
     name: Computer Room Air Conditioner
     abbreviation: CRAC
@@ -568,8 +573,8 @@ equipment:
       - supply-fan-status
       - discharge-air-temperature
       - zone-temperature
-      - cooling-setpoint
-      - heating-setpoint
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: packaged-terminal-heat-pump
     name: Packaged Terminal Heat Pump
     abbreviation: PTHP
@@ -623,8 +628,8 @@ equipment:
       - supply-fan-status
       - discharge-air-temperature
       - zone-temperature
-      - cooling-setpoint
-      - heating-setpoint
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: water-source-heat-pump
     name: Water Source Heat Pump
     abbreviation: WSHP
@@ -689,8 +694,6 @@ equipment:
       - supply-fan-status
       - discharge-air-temperature
       - zone-temperature
-      - entering-water-temperature
-      - leaving-water-temperature
   - id: air-source-heat-pump
     name: Air Source Heat Pump
     abbreviation: ASHP
@@ -756,9 +759,9 @@ equipment:
       - supply-fan-status
       - discharge-air-temperature
       - zone-temperature
-      - outside-air-temperature
-      - cooling-setpoint
-      - heating-setpoint
+      - outdoor-air-temperature
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: energy-recovery-ventilator
     name: Energy Recovery Ventilator
     abbreviation: ERV
@@ -825,7 +828,7 @@ equipment:
       - exhaust-fan-status
       - supply-air-temperature
       - exhaust-air-temperature
-      - outside-air-temperature
+      - outdoor-air-temperature
       - heat-wheel-output
   - id: heat-recovery-ventilator
     name: Heat Recovery Ventilator
@@ -880,7 +883,7 @@ equipment:
       - exhaust-fan-status
       - supply-air-temperature
       - exhaust-air-temperature
-      - outside-air-temperature
+      - outdoor-air-temperature
   - id: air-turnover-unit
     name: Air Turnover Unit
     abbreviation: ATU

--- a/data/equipment/central-plant.yaml
+++ b/data/equipment/central-plant.yaml
@@ -87,6 +87,9 @@ equipment:
       - chiller-alarm
       - chiller-entering-temperature
       - chiller-leaving-temperature
+      - chilled-water-supply-temperature
+      - chilled-water-return-temperature
+      - chilled-water-flow
   - id: boiler
     name: Boiler
     abbreviation: BLR
@@ -166,6 +169,9 @@ equipment:
       - boiler-alarm
       - hot-water-supply-temperature
       - hot-water-return-temperature
+      - hot-water-flow
+      - boiler-pump-command
+      - boiler-pump-status
   - id: cooling-tower
     name: Cooling Tower
     abbreviation: CT
@@ -229,6 +235,10 @@ equipment:
       - condenser-water-supply-temperature
       - condenser-water-return-temperature
       - cooling-tower-isolation-valve
+      - condenser-water-flow
+      - condenser-water-pump-command
+      - condenser-water-pump-status
+      - wet-bulb-temperature
   - id: heat-exchanger
     name: Heat Exchanger
     abbreviation: HX
@@ -274,8 +284,8 @@ equipment:
         - plate-ht-exchanger
         - plate heat exchanger
     typical_points:
-      - entering-water-temperature
-      - leaving-water-temperature
+      - chilled-water-supply-temperature
+      - chilled-water-return-temperature
   - id: pump
     name: Pump
     abbreviation: P
@@ -379,7 +389,8 @@ equipment:
       - hot-water-pump-output
       - hot-water-pump-status
       - hot-water-pump-alarm
-      - differential-pressure
+      - chilled-water-differential-pressure
+      - hot-water-differential-pressure
   - id: variable-frequency-drive
     name: Variable Frequency Drive
     abbreviation: VFD

--- a/data/equipment/metering.yaml
+++ b/data/equipment/metering.yaml
@@ -55,6 +55,15 @@ equipment:
         - electricitymeter
         - electricity meter
         - electricity-meter
+    typical_points:
+      - energy-consumption-kwh
+      - electrical-demand-kw
+      - power-factor
+      - voltage-sensor
+      - electrical-current-sensor
+      - apparent-power-kva
+      - reactive-power-kvar
+      - frequency-sensor
   - id: natural-gas-meter
     name: Natural Gas Meter
     abbreviation: GM
@@ -211,6 +220,8 @@ equipment:
         - stm mass flw meter
         - stm-mass-flw-meter
         - steam mass flow meter
+    typical_points:
+      - steam-flow
   - id: btu-meter
     name: BTU Meter
     abbreviation: BTU

--- a/data/equipment/terminal-units.yaml
+++ b/data/equipment/terminal-units.yaml
@@ -62,13 +62,10 @@ equipment:
     typical_points:
       - zone-temperature
       - discharge-air-temperature
-      - damper-position
-      - damper-output
-      - airflow
-      - airflow-setpoint
+      - supply-air-flow
       - heating-valve-output
-      - cooling-setpoint
-      - heating-setpoint
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: constant-air-volume-box
     name: Constant Air Volume Box
     abbreviation: CAV
@@ -119,8 +116,8 @@ equipment:
       - zone-temperature
       - discharge-air-temperature
       - heating-valve-output
-      - cooling-setpoint
-      - heating-setpoint
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: parallel-fan-powered-box
     name: Parallel Fan Powered Box
     abbreviation: PFPB
@@ -184,14 +181,12 @@ equipment:
     typical_points:
       - zone-temperature
       - discharge-air-temperature
-      - damper-position
-      - damper-output
       - supply-fan-command
       - supply-fan-status
-      - airflow
+      - supply-air-flow
       - heating-valve-output
-      - cooling-setpoint
-      - heating-setpoint
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: series-fan-powered-box
     name: Series Fan Powered Box
     abbreviation: SFPB
@@ -245,14 +240,12 @@ equipment:
     typical_points:
       - zone-temperature
       - discharge-air-temperature
-      - damper-position
-      - damper-output
       - supply-fan-command
       - supply-fan-status
-      - airflow
+      - supply-air-flow
       - heating-valve-output
-      - cooling-setpoint
-      - heating-setpoint
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: chilled-beam
     name: Chilled Beam
     abbreviation: CB
@@ -309,7 +302,7 @@ equipment:
     typical_points:
       - zone-temperature
       - cooling-valve-output
-      - cooling-setpoint
+      - occupied-cooling-setpoint
   - id: radiant-panel
     name: Radiant Panel
     abbreviation: RP
@@ -361,8 +354,8 @@ equipment:
       - zone-temperature
       - heating-valve-output
       - cooling-valve-output
-      - cooling-setpoint
-      - heating-setpoint
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: baseboard-heater
     name: Baseboard Heater
     abbreviation: BB
@@ -414,7 +407,7 @@ equipment:
     typical_points:
       - zone-temperature
       - heating-valve-output
-      - heating-setpoint
+      - occupied-heating-setpoint
   - id: unit-heater
     name: Unit Heater
     abbreviation: UH
@@ -479,7 +472,7 @@ equipment:
       - supply-fan-status
       - heating-valve-output
       - gas-fired-heat-output
-      - heating-setpoint
+      - occupied-heating-setpoint
   - id: induction-unit
     name: Induction Unit
     abbreviation: IU

--- a/data/equipment/vrf.yaml
+++ b/data/equipment/vrf.yaml
@@ -85,7 +85,7 @@ equipment:
         - outdoor condensing unit
         - variable refrigerant flow outdoor unit
     typical_points:
-      - outside-air-temperature
+      - outdoor-air-temperature
   - id: vrf-indoor-unit
     name: VRF Indoor Unit
     abbreviation: IDU
@@ -170,8 +170,8 @@ equipment:
       - discharge-air-temperature
       - supply-fan-command
       - supply-fan-status
-      - cooling-setpoint
-      - heating-setpoint
+      - occupied-cooling-setpoint
+      - occupied-heating-setpoint
   - id: vrf-branch-selector-box
     name: VRF Branch Selector Box
     abbreviation: BSB

--- a/data/points/alarms/boiler-alarm.yaml
+++ b/data/points/alarms/boiler-alarm.yaml
@@ -58,3 +58,8 @@ aliases:
     - boiler fault
     - boiler-alarm
     - boiler warning
+related:
+  - boiler-command
+  - boiler-feedback
+  - boiler-output
+  - boiler-status

--- a/data/points/alarms/boiler-pump-alarm.yaml
+++ b/data/points/alarms/boiler-pump-alarm.yaml
@@ -54,3 +54,8 @@ aliases:
     - boiler pump alm
     - boiler-pump-alm
     - boiler-pump-alarm
+related:
+  - boiler-pump-command
+  - boiler-pump-feedback
+  - boiler-pump-output
+  - boiler-pump-status

--- a/data/points/alarms/chilled-water-pump-alarm.yaml
+++ b/data/points/alarms/chilled-water-pump-alarm.yaml
@@ -47,3 +47,8 @@ aliases:
     - chilled water pump alm
     - chilled-water-pump-alm
     - chilled-water-pump-alarm
+related:
+  - chilled-water-pump-command
+  - chilled-water-pump-feedback
+  - chilled-water-pump-output
+  - chilled-water-pump-status

--- a/data/points/alarms/chiller-alarm.yaml
+++ b/data/points/alarms/chiller-alarm.yaml
@@ -69,3 +69,7 @@ aliases:
     - chiller fault
     - chiller-alarm
     - chiller warning
+related:
+  - chiller-command
+  - chiller-enable
+  - chiller-status

--- a/data/points/alarms/condenser-water-pump-alarm.yaml
+++ b/data/points/alarms/condenser-water-pump-alarm.yaml
@@ -46,3 +46,8 @@ aliases:
     - condenser water pump alm
     - condenser-water-pump-alm
     - condenser-water-pump-alarm
+related:
+  - condenser-water-pump-command
+  - condenser-water-pump-feedback
+  - condenser-water-pump-output
+  - condenser-water-pump-status

--- a/data/points/alarms/cooling-tower-alarm.yaml
+++ b/data/points/alarms/cooling-tower-alarm.yaml
@@ -73,3 +73,9 @@ aliases:
     - cooling-tower-alm
     - cooling tower fault
     - cooling-tower-alarm
+related:
+  - cooling-tower-command
+  - cooling-tower-enable
+  - cooling-tower-feedback
+  - cooling-tower-output
+  - cooling-tower-status

--- a/data/points/alarms/filter-alarm.yaml
+++ b/data/points/alarms/filter-alarm.yaml
@@ -44,3 +44,4 @@ aliases:
 
 related:
   - filter-differential-pressure
+  - filter-status

--- a/data/points/alarms/final-filter-alarm.yaml
+++ b/data/points/alarms/final-filter-alarm.yaml
@@ -48,3 +48,7 @@ aliases:
     - final filter alm
     - final-filter-alm
     - final-filter-alarm
+related:
+  - filter-differential-pressure
+  - final-filter-status
+  - prefilter-alarm

--- a/data/points/alarms/hot-water-pump-alarm.yaml
+++ b/data/points/alarms/hot-water-pump-alarm.yaml
@@ -46,3 +46,8 @@ aliases:
     - ht water pump alarm
     - ht-water-pump-alarm
     - hot-water-pump-alarm
+related:
+  - hot-water-pump-command
+  - hot-water-pump-feedback
+  - hot-water-pump-output
+  - hot-water-pump-status

--- a/data/points/alarms/low-limit-alarm.yaml
+++ b/data/points/alarms/low-limit-alarm.yaml
@@ -51,3 +51,6 @@ aliases:
     - lowtemperaturealm
     - low temperature alm
     - low-temperature-alm
+related:
+  - discharge-air-temperature
+  - mixed-air-temperature

--- a/data/points/alarms/prefilter-alarm.yaml
+++ b/data/points/alarms/prefilter-alarm.yaml
@@ -46,3 +46,7 @@ aliases:
     - pre filt alarm
     - prefilter-alarm
     - pre filter alarm
+related:
+  - filter-differential-pressure
+  - final-filter-alarm
+  - prefilter-status

--- a/data/points/alarms/primary-chilled-water-pump-alarm.yaml
+++ b/data/points/alarms/primary-chilled-water-pump-alarm.yaml
@@ -45,3 +45,8 @@ aliases:
     - primary chilled water pump alm
     - primary-chilled-water-pump-alm
     - primary-chilled-water-pump-alarm
+related:
+  - primary-chilled-water-pump-command
+  - primary-chilled-water-pump-feedback
+  - primary-chilled-water-pump-output
+  - primary-chilled-water-pump-status

--- a/data/points/alarms/secondary-chilled-water-pump-alarm.yaml
+++ b/data/points/alarms/secondary-chilled-water-pump-alarm.yaml
@@ -46,3 +46,8 @@ aliases:
     - secondary chilled water pump alm
     - secondary-chilled-water-pump-alm
     - secondary-chilled-water-pump-alarm
+related:
+  - secondary-chilled-water-pump-command
+  - secondary-chilled-water-pump-feedback
+  - secondary-chilled-water-pump-output
+  - secondary-chilled-water-pump-status

--- a/data/points/alarms/smoke-alarm.yaml
+++ b/data/points/alarms/smoke-alarm.yaml
@@ -38,3 +38,6 @@ aliases:
     - smokedetect
     - smoke detect
     - smoke-detect
+related:
+  - fire-alarm-status
+  - smoke-damper-open

--- a/data/points/commands/boiler-command.yaml
+++ b/data/points/commands/boiler-command.yaml
@@ -60,3 +60,8 @@ aliases:
     - blr-start/stop
     - boiler-command
     - boiler start/stop
+related:
+  - boiler-alarm
+  - boiler-feedback
+  - boiler-output
+  - boiler-status

--- a/data/points/commands/boiler-feedback.yaml
+++ b/data/points/commands/boiler-feedback.yaml
@@ -45,4 +45,7 @@ aliases:
     - boiler modulation fb
     - boiler firing rate fb
 related:
+  - boiler-alarm
+  - boiler-command
   - boiler-output
+  - boiler-status

--- a/data/points/commands/boiler-output.yaml
+++ b/data/points/commands/boiler-output.yaml
@@ -44,4 +44,7 @@ aliases:
     - boiler modulation
     - boiler firing rate
 related:
+  - boiler-alarm
+  - boiler-command
   - boiler-feedback
+  - boiler-status

--- a/data/points/commands/boiler-pump-command.yaml
+++ b/data/points/commands/boiler-pump-command.yaml
@@ -50,3 +50,8 @@ aliases:
     - blr pump command
     - blr-pump-command
     - boiler-pump-command
+related:
+  - boiler-pump-alarm
+  - boiler-pump-feedback
+  - boiler-pump-output
+  - boiler-pump-status

--- a/data/points/commands/boiler-pump-feedback.yaml
+++ b/data/points/commands/boiler-pump-feedback.yaml
@@ -41,4 +41,7 @@ aliases:
     - blr-pump-feedback
     - boiler-pump-feedback
 related:
+  - boiler-pump-alarm
+  - boiler-pump-command
   - boiler-pump-output
+  - boiler-pump-status

--- a/data/points/commands/boiler-pump-output.yaml
+++ b/data/points/commands/boiler-pump-output.yaml
@@ -41,4 +41,7 @@ aliases:
     - boiler-pump-out
     - boiler-pump-output
 related:
+  - boiler-pump-alarm
+  - boiler-pump-command
   - boiler-pump-feedback
+  - boiler-pump-status

--- a/data/points/commands/chilled-water-pump-command.yaml
+++ b/data/points/commands/chilled-water-pump-command.yaml
@@ -43,3 +43,8 @@ aliases:
     - chl water pump command
     - chl-water-pump-command
     - chilled-water-pump-command
+related:
+  - chilled-water-pump-alarm
+  - chilled-water-pump-feedback
+  - chilled-water-pump-output
+  - chilled-water-pump-status

--- a/data/points/commands/chilled-water-pump-feedback.yaml
+++ b/data/points/commands/chilled-water-pump-feedback.yaml
@@ -34,4 +34,7 @@ aliases:
     - chl-water-pump-feedback
     - chilled-water-pump-feedback
 related:
+  - chilled-water-pump-alarm
+  - chilled-water-pump-command
   - chilled-water-pump-output
+  - chilled-water-pump-status

--- a/data/points/commands/chilled-water-pump-output.yaml
+++ b/data/points/commands/chilled-water-pump-output.yaml
@@ -34,4 +34,7 @@ aliases:
     - chilled-water-pump-out
     - chilled-water-pump-output
 related:
+  - chilled-water-pump-alarm
+  - chilled-water-pump-command
   - chilled-water-pump-feedback
+  - chilled-water-pump-status

--- a/data/points/commands/chiller-command.yaml
+++ b/data/points/commands/chiller-command.yaml
@@ -58,3 +58,7 @@ aliases:
     - chl-start/stop
     - chiller-command
     - chiller start/stop
+related:
+  - chiller-alarm
+  - chiller-enable
+  - chiller-status

--- a/data/points/commands/chiller-enable.yaml
+++ b/data/points/commands/chiller-enable.yaml
@@ -56,3 +56,7 @@ aliases:
     - chiller on/off
     - chiller-enable
     - chiller enabled
+related:
+  - chiller-alarm
+  - chiller-command
+  - chiller-status

--- a/data/points/commands/condenser-water-pump-command.yaml
+++ b/data/points/commands/condenser-water-pump-command.yaml
@@ -42,3 +42,8 @@ aliases:
     - condenser water pump cmd
     - condenser-water-pump-cmd
     - condenser-water-pump-command
+related:
+  - condenser-water-pump-alarm
+  - condenser-water-pump-feedback
+  - condenser-water-pump-output
+  - condenser-water-pump-status

--- a/data/points/commands/condenser-water-pump-feedback.yaml
+++ b/data/points/commands/condenser-water-pump-feedback.yaml
@@ -34,4 +34,7 @@ aliases:
     - condenser-water-pump-fb
     - condenser-water-pump-feedback
 related:
+  - condenser-water-pump-alarm
+  - condenser-water-pump-command
   - condenser-water-pump-output
+  - condenser-water-pump-status

--- a/data/points/commands/condenser-water-pump-output.yaml
+++ b/data/points/commands/condenser-water-pump-output.yaml
@@ -33,4 +33,7 @@ aliases:
     - condenser-water-pump-out
     - condenser-water-pump-output
 related:
+  - condenser-water-pump-alarm
+  - condenser-water-pump-command
   - condenser-water-pump-feedback
+  - condenser-water-pump-status

--- a/data/points/commands/cooling-enable.yaml
+++ b/data/points/commands/cooling-enable.yaml
@@ -38,3 +38,8 @@ aliases:
     - cooling-en
     - cool enable
     - cooling-enable
+related:
+  - cooling-valve-output
+  - dx-cooling-stage
+  - heating-enable
+  - occupied-cooling-setpoint

--- a/data/points/commands/cooling-tower-command.yaml
+++ b/data/points/commands/cooling-tower-command.yaml
@@ -65,3 +65,11 @@ aliases:
     - cool-tw-start/stop
     - cooling-tower-command
     - cooling tower start/stop
+related:
+  - condenser-water-supply-temperature-setpoint
+  - cooling-tower-alarm
+  - cooling-tower-enable
+  - cooling-tower-feedback
+  - cooling-tower-isolation-valve
+  - cooling-tower-output
+  - cooling-tower-status

--- a/data/points/commands/cooling-tower-enable.yaml
+++ b/data/points/commands/cooling-tower-enable.yaml
@@ -59,3 +59,9 @@ aliases:
     - cooling-tower-en
     - cooling-tower-enable
     - cooling tower enabled
+related:
+  - cooling-tower-alarm
+  - cooling-tower-command
+  - cooling-tower-feedback
+  - cooling-tower-output
+  - cooling-tower-status

--- a/data/points/commands/cooling-tower-feedback.yaml
+++ b/data/points/commands/cooling-tower-feedback.yaml
@@ -69,4 +69,8 @@ aliases:
     - cooling tower speed fb
     - cooling-tower-feedback
 related:
+  - cooling-tower-alarm
+  - cooling-tower-command
+  - cooling-tower-enable
   - cooling-tower-output
+  - cooling-tower-status

--- a/data/points/commands/cooling-tower-output.yaml
+++ b/data/points/commands/cooling-tower-output.yaml
@@ -67,4 +67,9 @@ aliases:
     - cooling tower speed
     - cooling-tower-output
 related:
+  - cooling-tower-alarm
+  - cooling-tower-command
+  - cooling-tower-enable
   - cooling-tower-feedback
+  - cooling-tower-isolation-valve
+  - cooling-tower-status

--- a/data/points/commands/economizer-enable.yaml
+++ b/data/points/commands/economizer-enable.yaml
@@ -34,3 +34,6 @@ aliases:
     - economizer en
     - economizer-en
     - economizer-enable
+related:
+  - outdoor-air-temperature
+  - outside-air-damper-output

--- a/data/points/commands/heat-wheel-command.yaml
+++ b/data/points/commands/heat-wheel-command.yaml
@@ -57,3 +57,7 @@ aliases:
     - nrg recovery whl cmd
     - nrg-recovery-whl-cmd
     - energy recovery wheel command
+related:
+  - heat-wheel-feedback
+  - heat-wheel-output
+  - heat-wheel-status

--- a/data/points/commands/heat-wheel-feedback.yaml
+++ b/data/points/commands/heat-wheel-feedback.yaml
@@ -50,4 +50,6 @@ aliases:
     - nrg-recovery-whl-fb
     - energy recovery wheel feedback
 related:
+  - heat-wheel-command
   - heat-wheel-output
+  - heat-wheel-status

--- a/data/points/commands/heat-wheel-output.yaml
+++ b/data/points/commands/heat-wheel-output.yaml
@@ -48,4 +48,6 @@ aliases:
     - nrg-recovery-whl-out
     - energy recovery wheel output
 related:
+  - heat-wheel-command
   - heat-wheel-feedback
+  - heat-wheel-status

--- a/data/points/commands/heating-enable.yaml
+++ b/data/points/commands/heating-enable.yaml
@@ -44,3 +44,8 @@ aliases:
     - htg-enable
     - heat enable
     - heating-enable
+related:
+  - cooling-enable
+  - electric-heat-stage
+  - heating-valve-output
+  - occupied-heating-setpoint

--- a/data/points/commands/hot-water-pump-command.yaml
+++ b/data/points/commands/hot-water-pump-command.yaml
@@ -42,3 +42,8 @@ aliases:
     - ht water pump command
     - ht-water-pump-command
     - hot-water-pump-command
+related:
+  - hot-water-pump-alarm
+  - hot-water-pump-feedback
+  - hot-water-pump-output
+  - hot-water-pump-status

--- a/data/points/commands/hot-water-pump-feedback.yaml
+++ b/data/points/commands/hot-water-pump-feedback.yaml
@@ -34,4 +34,7 @@ aliases:
     - ht-water-pump-feedback
     - hot-water-pump-feedback
 related:
+  - hot-water-pump-alarm
+  - hot-water-pump-command
   - hot-water-pump-output
+  - hot-water-pump-status

--- a/data/points/commands/hot-water-pump-output.yaml
+++ b/data/points/commands/hot-water-pump-output.yaml
@@ -33,4 +33,7 @@ aliases:
     - ht-water-pump-output
     - hot-water-pump-output
 related:
+  - hot-water-pump-alarm
+  - hot-water-pump-command
   - hot-water-pump-feedback
+  - hot-water-pump-status

--- a/data/points/commands/occupied-command.yaml
+++ b/data/points/commands/occupied-command.yaml
@@ -39,3 +39,9 @@ aliases:
     - occupancy cmd
     - occupancy-cmd
     - occupied-command
+related:
+  - effective-occupancy
+  - occupancy
+  - occupancy-schedule
+  - system-enable
+  - unit-enable-mode

--- a/data/points/commands/primary-chilled-water-pump-command.yaml
+++ b/data/points/commands/primary-chilled-water-pump-command.yaml
@@ -41,3 +41,8 @@ aliases:
     - primary chilled water pump cmd
     - primary-chilled-water-pump-cmd
     - primary-chilled-water-pump-command
+related:
+  - primary-chilled-water-pump-alarm
+  - primary-chilled-water-pump-feedback
+  - primary-chilled-water-pump-output
+  - primary-chilled-water-pump-status

--- a/data/points/commands/primary-chilled-water-pump-feedback.yaml
+++ b/data/points/commands/primary-chilled-water-pump-feedback.yaml
@@ -32,4 +32,7 @@ aliases:
     - pri-chilled-water-pump-feedback
     - primary-chilled-water-pump-feedback
 related:
+  - primary-chilled-water-pump-alarm
+  - primary-chilled-water-pump-command
   - primary-chilled-water-pump-output
+  - primary-chilled-water-pump-status

--- a/data/points/commands/primary-chilled-water-pump-output.yaml
+++ b/data/points/commands/primary-chilled-water-pump-output.yaml
@@ -32,4 +32,7 @@ aliases:
     - primary-chilled-water-pump-out
     - primary-chilled-water-pump-output
 related:
+  - primary-chilled-water-pump-alarm
+  - primary-chilled-water-pump-command
   - primary-chilled-water-pump-feedback
+  - primary-chilled-water-pump-status

--- a/data/points/commands/secondary-chilled-water-pump-command.yaml
+++ b/data/points/commands/secondary-chilled-water-pump-command.yaml
@@ -41,3 +41,8 @@ aliases:
     - secondary chilled water pump cmd
     - secondary-chilled-water-pump-cmd
     - secondary-chilled-water-pump-command
+related:
+  - secondary-chilled-water-pump-alarm
+  - secondary-chilled-water-pump-feedback
+  - secondary-chilled-water-pump-output
+  - secondary-chilled-water-pump-status

--- a/data/points/commands/secondary-chilled-water-pump-feedback.yaml
+++ b/data/points/commands/secondary-chilled-water-pump-feedback.yaml
@@ -32,4 +32,7 @@ aliases:
     - secondary-chilled-water-pump-fb
     - secondary-chilled-water-pump-feedback
 related:
+  - secondary-chilled-water-pump-alarm
+  - secondary-chilled-water-pump-command
   - secondary-chilled-water-pump-output
+  - secondary-chilled-water-pump-status

--- a/data/points/commands/secondary-chilled-water-pump-output.yaml
+++ b/data/points/commands/secondary-chilled-water-pump-output.yaml
@@ -32,4 +32,7 @@ aliases:
     - secondary-chilled-water-pump-out
     - secondary-chilled-water-pump-output
 related:
+  - secondary-chilled-water-pump-alarm
+  - secondary-chilled-water-pump-command
   - secondary-chilled-water-pump-feedback
+  - secondary-chilled-water-pump-status

--- a/data/points/commands/steam-heating-output.yaml
+++ b/data/points/commands/steam-heating-output.yaml
@@ -50,4 +50,5 @@ aliases:
     - stm-heating-output
     - steam-heating-output
 related:
+  - steam-flow
   - steam-heating-feedback

--- a/data/points/commands/system-enable.yaml
+++ b/data/points/commands/system-enable.yaml
@@ -34,3 +34,7 @@ aliases:
     - system enbl
     - system-enbl
     - system-enable
+related:
+  - occupied-command
+  - shutdown
+  - unit-enable-mode

--- a/data/points/commands/unit-enable-mode.yaml
+++ b/data/points/commands/unit-enable-mode.yaml
@@ -39,3 +39,6 @@ aliases:
     - unt-enbl-mode
     - unit enable mode
     - unit-enable-mode
+related:
+  - occupied-command
+  - system-enable

--- a/data/points/dampers/exhaust-air-damper-closed.yaml
+++ b/data/points/dampers/exhaust-air-damper-closed.yaml
@@ -42,3 +42,8 @@ aliases:
     - exh air damper closed
     - exh-air-damper-closed
     - exhaust-air-damper-closed
+related:
+  - exhaust-air-damper-feedback
+  - exhaust-air-damper-open
+  - exhaust-air-damper-output
+  - exhaust-air-damper-position

--- a/data/points/dampers/exhaust-air-damper-feedback.yaml
+++ b/data/points/dampers/exhaust-air-damper-feedback.yaml
@@ -42,4 +42,7 @@ aliases:
     - exh-air-damper-feedback
     - exhaust-air-damper-feedback
 related:
+  - exhaust-air-damper-closed
+  - exhaust-air-damper-open
   - exhaust-air-damper-output
+  - exhaust-air-damper-position

--- a/data/points/dampers/exhaust-air-damper-open.yaml
+++ b/data/points/dampers/exhaust-air-damper-open.yaml
@@ -42,3 +42,8 @@ aliases:
     - exh air damper open
     - exh-air-damper-open
     - exhaust-air-damper-open
+related:
+  - exhaust-air-damper-closed
+  - exhaust-air-damper-feedback
+  - exhaust-air-damper-output
+  - exhaust-air-damper-position

--- a/data/points/dampers/exhaust-air-damper-output.yaml
+++ b/data/points/dampers/exhaust-air-damper-output.yaml
@@ -41,4 +41,9 @@ aliases:
     - exhaust-air-damper-out
     - exhaust-air-damper-output
 related:
+  - building-pressure
+  - exhaust-air-damper-closed
   - exhaust-air-damper-feedback
+  - exhaust-air-damper-open
+  - exhaust-air-damper-position
+  - exhaust-air-flow

--- a/data/points/dampers/exhaust-air-damper-position.yaml
+++ b/data/points/dampers/exhaust-air-damper-position.yaml
@@ -40,3 +40,8 @@ aliases:
     - exh air damper position
     - exh-air-damper-position
     - exhaust-air-damper-position
+related:
+  - exhaust-air-damper-closed
+  - exhaust-air-damper-feedback
+  - exhaust-air-damper-open
+  - exhaust-air-damper-output

--- a/data/points/dampers/mixed-air-damper-closed.yaml
+++ b/data/points/dampers/mixed-air-damper-closed.yaml
@@ -42,3 +42,8 @@ aliases:
     - ma air damper closed
     - ma-air-damper-closed
     - mixed-air-damper-closed
+related:
+  - mixed-air-damper-feedback
+  - mixed-air-damper-open
+  - mixed-air-damper-output
+  - mixed-air-damper-position

--- a/data/points/dampers/mixed-air-damper-feedback.yaml
+++ b/data/points/dampers/mixed-air-damper-feedback.yaml
@@ -42,4 +42,7 @@ aliases:
     - ma-air-damper-feedback
     - mixed-air-damper-feedback
 related:
+  - mixed-air-damper-closed
+  - mixed-air-damper-open
   - mixed-air-damper-output
+  - mixed-air-damper-position

--- a/data/points/dampers/mixed-air-damper-open.yaml
+++ b/data/points/dampers/mixed-air-damper-open.yaml
@@ -42,3 +42,8 @@ aliases:
     - ma air damper open
     - ma-air-damper-open
     - mixed-air-damper-open
+related:
+  - mixed-air-damper-closed
+  - mixed-air-damper-feedback
+  - mixed-air-damper-output
+  - mixed-air-damper-position

--- a/data/points/dampers/mixed-air-damper-output.yaml
+++ b/data/points/dampers/mixed-air-damper-output.yaml
@@ -41,4 +41,7 @@ aliases:
     - mixed-air-damper-out
     - mixed-air-damper-output
 related:
+  - mixed-air-damper-closed
   - mixed-air-damper-feedback
+  - mixed-air-damper-open
+  - mixed-air-damper-position

--- a/data/points/dampers/mixed-air-damper-position.yaml
+++ b/data/points/dampers/mixed-air-damper-position.yaml
@@ -40,3 +40,8 @@ aliases:
     - ma air damper position
     - ma-air-damper-position
     - mixed-air-damper-position
+related:
+  - mixed-air-damper-closed
+  - mixed-air-damper-feedback
+  - mixed-air-damper-open
+  - mixed-air-damper-output

--- a/data/points/dampers/outside-air-damper-closed.yaml
+++ b/data/points/dampers/outside-air-damper-closed.yaml
@@ -43,3 +43,8 @@ aliases:
     - oa-air-damper-closed
     - outdoor air damper closed
     - outside-air-damper-closed
+related:
+  - outside-air-damper-feedback
+  - outside-air-damper-open
+  - outside-air-damper-output
+  - outside-air-damper-position

--- a/data/points/dampers/outside-air-damper-feedback.yaml
+++ b/data/points/dampers/outside-air-damper-feedback.yaml
@@ -43,4 +43,7 @@ aliases:
     - outdoor air damper feedback
     - outside-air-damper-feedback
 related:
+  - outside-air-damper-closed
+  - outside-air-damper-open
   - outside-air-damper-output
+  - outside-air-damper-position

--- a/data/points/dampers/outside-air-damper-open.yaml
+++ b/data/points/dampers/outside-air-damper-open.yaml
@@ -43,3 +43,8 @@ aliases:
     - oa-air-damper-open
     - outdoor air damper open
     - outside-air-damper-open
+related:
+  - outside-air-damper-closed
+  - outside-air-damper-feedback
+  - outside-air-damper-output
+  - outside-air-damper-position

--- a/data/points/dampers/outside-air-damper-output.yaml
+++ b/data/points/dampers/outside-air-damper-output.yaml
@@ -42,4 +42,11 @@ aliases:
     - outdoor air damper output
     - outside-air-damper-output
 related:
+  - economizer-enable
+  - minimum-outdoor-airflow-setpoint
+  - outdoor-air-flow
+  - outdoor-air-temperature
+  - outside-air-damper-closed
   - outside-air-damper-feedback
+  - outside-air-damper-open
+  - outside-air-damper-position

--- a/data/points/dampers/outside-air-damper-position.yaml
+++ b/data/points/dampers/outside-air-damper-position.yaml
@@ -41,3 +41,8 @@ aliases:
     - outside-air-damper-pos
     - outdoor air damper position
     - outside-air-damper-position
+related:
+  - outside-air-damper-closed
+  - outside-air-damper-feedback
+  - outside-air-damper-open
+  - outside-air-damper-output

--- a/data/points/dampers/relief-air-damper-closed.yaml
+++ b/data/points/dampers/relief-air-damper-closed.yaml
@@ -41,3 +41,8 @@ aliases:
     - rel air damper closed
     - rel-air-damper-closed
     - relief-air-damper-closed
+related:
+  - relief-air-damper-feedback
+  - relief-air-damper-open
+  - relief-air-damper-output
+  - relief-air-damper-position

--- a/data/points/dampers/relief-air-damper-feedback.yaml
+++ b/data/points/dampers/relief-air-damper-feedback.yaml
@@ -41,4 +41,7 @@ aliases:
     - rel-air-damper-feedback
     - relief-air-damper-feedback
 related:
+  - relief-air-damper-closed
+  - relief-air-damper-open
   - relief-air-damper-output
+  - relief-air-damper-position

--- a/data/points/dampers/relief-air-damper-open.yaml
+++ b/data/points/dampers/relief-air-damper-open.yaml
@@ -41,3 +41,8 @@ aliases:
     - rel air damper open
     - rel-air-damper-open
     - relief-air-damper-open
+related:
+  - relief-air-damper-closed
+  - relief-air-damper-feedback
+  - relief-air-damper-output
+  - relief-air-damper-position

--- a/data/points/dampers/relief-air-damper-output.yaml
+++ b/data/points/dampers/relief-air-damper-output.yaml
@@ -41,4 +41,8 @@ aliases:
     - relief-air-damper-out
     - relief-air-damper-output
 related:
+  - building-pressure
+  - relief-air-damper-closed
   - relief-air-damper-feedback
+  - relief-air-damper-open
+  - relief-air-damper-position

--- a/data/points/dampers/relief-air-damper-position.yaml
+++ b/data/points/dampers/relief-air-damper-position.yaml
@@ -40,3 +40,9 @@ aliases:
     - rel air damper position
     - rel-air-damper-position
     - relief-air-damper-position
+related:
+  - building-pressure-setpoint
+  - relief-air-damper-closed
+  - relief-air-damper-feedback
+  - relief-air-damper-open
+  - relief-air-damper-output

--- a/data/points/dampers/smoke-damper-open.yaml
+++ b/data/points/dampers/smoke-damper-open.yaml
@@ -52,3 +52,6 @@ aliases:
     - smoke dpr output
     - smoke-damper-open
     - smoke damper output
+related:
+  - fire-alarm-status
+  - smoke-alarm

--- a/data/points/electrical/apparent-power-kva.yaml
+++ b/data/points/electrical/apparent-power-kva.yaml
@@ -22,6 +22,10 @@ notes:
   - Used for sizing transformers, generators, and UPS systems
 
 related:
+  - electrical-current-sensor
   - electrical-demand-kw
-  - reactive-power-kvar
+  - energy-consumption-kwh
+  - frequency-sensor
   - power-factor
+  - reactive-power-kvar
+  - voltage-sensor

--- a/data/points/electrical/electrical-current-sensor.yaml
+++ b/data/points/electrical/electrical-current-sensor.yaml
@@ -27,6 +27,10 @@ notes:
   - Used with voltage for calculating power (P = V × I × PF)
 
 related:
-  - voltage-sensor
+  - apparent-power-kva
   - electrical-demand-kw
+  - energy-consumption-kwh
+  - frequency-sensor
   - power-factor
+  - reactive-power-kvar
+  - voltage-sensor

--- a/data/points/electrical/electrical-demand-kw.yaml
+++ b/data/points/electrical/electrical-demand-kw.yaml
@@ -28,6 +28,10 @@ notes:
   - Typically read from a power meter or CT (current transformer) metering
 
 related:
+  - apparent-power-kva
+  - electrical-current-sensor
   - energy-consumption-kwh
+  - frequency-sensor
   - power-factor
-  - electrical-current-rms
+  - reactive-power-kvar
+  - voltage-sensor

--- a/data/points/electrical/energy-consumption-kwh.yaml
+++ b/data/points/electrical/energy-consumption-kwh.yaml
@@ -28,4 +28,10 @@ notes:
   - Often tracked per equipment, floor, or building
 
 related:
+  - apparent-power-kva
+  - electrical-current-sensor
   - electrical-demand-kw
+  - frequency-sensor
+  - power-factor
+  - reactive-power-kvar
+  - voltage-sensor

--- a/data/points/electrical/frequency-sensor.yaml
+++ b/data/points/electrical/frequency-sensor.yaml
@@ -24,5 +24,10 @@ notes:
   - Critical for generator synchronization and UPS systems
 
 related:
-  - voltage-sensor
+  - apparent-power-kva
   - electrical-current-sensor
+  - electrical-demand-kw
+  - energy-consumption-kwh
+  - power-factor
+  - reactive-power-kvar
+  - voltage-sensor

--- a/data/points/electrical/power-factor.yaml
+++ b/data/points/electrical/power-factor.yaml
@@ -23,6 +23,10 @@ notes:
   - Can be improved with capacitor banks or VFDs
 
 related:
-  - electrical-demand-kw
-  - reactive-power-kvar
   - apparent-power-kva
+  - electrical-current-sensor
+  - electrical-demand-kw
+  - energy-consumption-kwh
+  - frequency-sensor
+  - reactive-power-kvar
+  - voltage-sensor

--- a/data/points/electrical/reactive-power-kvar.yaml
+++ b/data/points/electrical/reactive-power-kvar.yaml
@@ -24,5 +24,9 @@ notes:
 
 related:
   - apparent-power-kva
-  - power-factor
+  - electrical-current-sensor
   - electrical-demand-kw
+  - energy-consumption-kwh
+  - frequency-sensor
+  - power-factor
+  - voltage-sensor

--- a/data/points/electrical/voltage-sensor.yaml
+++ b/data/points/electrical/voltage-sensor.yaml
@@ -26,6 +26,10 @@ notes:
   - Often measured per phase (A, B, C) on three-phase systems
 
 related:
+  - apparent-power-kva
   - electrical-current-sensor
   - electrical-demand-kw
+  - energy-consumption-kwh
   - frequency-sensor
+  - power-factor
+  - reactive-power-kvar

--- a/data/points/fans/exhaust-fan-alarm.yaml
+++ b/data/points/fans/exhaust-fan-alarm.yaml
@@ -45,3 +45,10 @@ aliases:
     - exhaust fan alm
     - exhaust-fan-alm
     - exhaust-fan-alarm
+related:
+  - exhaust-fan-command
+  - exhaust-fan-fault
+  - exhaust-fan-feedback
+  - exhaust-fan-output
+  - exhaust-fan-speed
+  - exhaust-fan-status

--- a/data/points/fans/exhaust-fan-command.yaml
+++ b/data/points/fans/exhaust-fan-command.yaml
@@ -40,3 +40,10 @@ aliases:
     - exhaust fan cmd
     - exhaust-fan-cmd
     - exhaust-fan-command
+related:
+  - exhaust-fan-alarm
+  - exhaust-fan-fault
+  - exhaust-fan-feedback
+  - exhaust-fan-output
+  - exhaust-fan-speed
+  - exhaust-fan-status

--- a/data/points/fans/exhaust-fan-fault.yaml
+++ b/data/points/fans/exhaust-fan-fault.yaml
@@ -37,3 +37,10 @@ aliases:
     - exh fan fault
     - exh-fan-fault
     - exhaust-fan-fault
+related:
+  - exhaust-fan-alarm
+  - exhaust-fan-command
+  - exhaust-fan-feedback
+  - exhaust-fan-output
+  - exhaust-fan-speed
+  - exhaust-fan-status

--- a/data/points/fans/exhaust-fan-feedback.yaml
+++ b/data/points/fans/exhaust-fan-feedback.yaml
@@ -32,4 +32,9 @@ aliases:
     - exh-fan-feedback
     - exhaust-fan-feedback
 related:
+  - exhaust-fan-alarm
+  - exhaust-fan-command
+  - exhaust-fan-fault
   - exhaust-fan-output
+  - exhaust-fan-speed
+  - exhaust-fan-status

--- a/data/points/fans/exhaust-fan-output.yaml
+++ b/data/points/fans/exhaust-fan-output.yaml
@@ -31,4 +31,9 @@ aliases:
     - exhaust-fan-out
     - exhaust-fan-output
 related:
+  - exhaust-fan-alarm
+  - exhaust-fan-command
+  - exhaust-fan-fault
   - exhaust-fan-feedback
+  - exhaust-fan-speed
+  - exhaust-fan-status

--- a/data/points/fans/exhaust-fan-speed.yaml
+++ b/data/points/fans/exhaust-fan-speed.yaml
@@ -34,3 +34,11 @@ aliases:
     - exhaust fan spd
     - exhaust-fan-spd
     - exhaust-fan-speed
+related:
+  - exhaust-air-flow
+  - exhaust-fan-alarm
+  - exhaust-fan-command
+  - exhaust-fan-fault
+  - exhaust-fan-feedback
+  - exhaust-fan-output
+  - exhaust-fan-status

--- a/data/points/fans/exhaust-fan-status.yaml
+++ b/data/points/fans/exhaust-fan-status.yaml
@@ -44,3 +44,10 @@ aliases:
     - exhaust fan sts
     - exhaust-fan-sts
     - exhaust-fan-status
+related:
+  - exhaust-fan-alarm
+  - exhaust-fan-command
+  - exhaust-fan-fault
+  - exhaust-fan-feedback
+  - exhaust-fan-output
+  - exhaust-fan-speed

--- a/data/points/fans/relief-fan-alarm.yaml
+++ b/data/points/fans/relief-fan-alarm.yaml
@@ -46,3 +46,10 @@ aliases:
     - relief fan alm
     - relief-fan-alm
     - relief-fan-alarm
+related:
+  - relief-fan-command
+  - relief-fan-fault
+  - relief-fan-feedback
+  - relief-fan-output
+  - relief-fan-speed
+  - relief-fan-status

--- a/data/points/fans/relief-fan-command.yaml
+++ b/data/points/fans/relief-fan-command.yaml
@@ -41,3 +41,10 @@ aliases:
     - rel fan command
     - rel-fan-command
     - relief-fan-command
+related:
+  - relief-fan-alarm
+  - relief-fan-fault
+  - relief-fan-feedback
+  - relief-fan-output
+  - relief-fan-speed
+  - relief-fan-status

--- a/data/points/fans/relief-fan-fault.yaml
+++ b/data/points/fans/relief-fan-fault.yaml
@@ -37,3 +37,10 @@ aliases:
     - rel fan fault
     - rel-fan-fault
     - relief-fan-fault
+related:
+  - relief-fan-alarm
+  - relief-fan-command
+  - relief-fan-feedback
+  - relief-fan-output
+  - relief-fan-speed
+  - relief-fan-status

--- a/data/points/fans/relief-fan-feedback.yaml
+++ b/data/points/fans/relief-fan-feedback.yaml
@@ -32,4 +32,9 @@ aliases:
     - rel-fan-feedback
     - relief-fan-feedback
 related:
+  - relief-fan-alarm
+  - relief-fan-command
+  - relief-fan-fault
   - relief-fan-output
+  - relief-fan-speed
+  - relief-fan-status

--- a/data/points/fans/relief-fan-output.yaml
+++ b/data/points/fans/relief-fan-output.yaml
@@ -32,4 +32,9 @@ aliases:
     - relief-fan-out
     - relief-fan-output
 related:
+  - relief-fan-alarm
+  - relief-fan-command
+  - relief-fan-fault
   - relief-fan-feedback
+  - relief-fan-speed
+  - relief-fan-status

--- a/data/points/fans/relief-fan-speed.yaml
+++ b/data/points/fans/relief-fan-speed.yaml
@@ -35,3 +35,10 @@ aliases:
     - relief fan spd
     - relief-fan-spd
     - relief-fan-speed
+related:
+  - relief-fan-alarm
+  - relief-fan-command
+  - relief-fan-fault
+  - relief-fan-feedback
+  - relief-fan-output
+  - relief-fan-status

--- a/data/points/fans/relief-fan-status.yaml
+++ b/data/points/fans/relief-fan-status.yaml
@@ -45,3 +45,10 @@ aliases:
     - relief fan sts
     - relief-fan-sts
     - relief-fan-status
+related:
+  - relief-fan-alarm
+  - relief-fan-command
+  - relief-fan-fault
+  - relief-fan-feedback
+  - relief-fan-output
+  - relief-fan-speed

--- a/data/points/fans/return-fan-alarm.yaml
+++ b/data/points/fans/return-fan-alarm.yaml
@@ -45,3 +45,10 @@ aliases:
     - return fan alm
     - return-fan-alm
     - return-fan-alarm
+related:
+  - return-fan-command
+  - return-fan-fault
+  - return-fan-feedback
+  - return-fan-output
+  - return-fan-speed
+  - return-fan-status

--- a/data/points/fans/return-fan-command.yaml
+++ b/data/points/fans/return-fan-command.yaml
@@ -40,3 +40,10 @@ aliases:
     - ret fan command
     - ret-fan-command
     - return-fan-command
+related:
+  - return-fan-alarm
+  - return-fan-fault
+  - return-fan-feedback
+  - return-fan-output
+  - return-fan-speed
+  - return-fan-status

--- a/data/points/fans/return-fan-fault.yaml
+++ b/data/points/fans/return-fan-fault.yaml
@@ -37,3 +37,10 @@ aliases:
     - ret fan fault
     - ret-fan-fault
     - return-fan-fault
+related:
+  - return-fan-alarm
+  - return-fan-command
+  - return-fan-feedback
+  - return-fan-output
+  - return-fan-speed
+  - return-fan-status

--- a/data/points/fans/return-fan-feedback.yaml
+++ b/data/points/fans/return-fan-feedback.yaml
@@ -32,4 +32,9 @@ aliases:
     - ret-fan-feedback
     - return-fan-feedback
 related:
+  - return-fan-alarm
+  - return-fan-command
+  - return-fan-fault
   - return-fan-output
+  - return-fan-speed
+  - return-fan-status

--- a/data/points/fans/return-fan-output.yaml
+++ b/data/points/fans/return-fan-output.yaml
@@ -31,4 +31,9 @@ aliases:
     - return-fan-out
     - return-fan-output
 related:
+  - return-fan-alarm
+  - return-fan-command
+  - return-fan-fault
   - return-fan-feedback
+  - return-fan-speed
+  - return-fan-status

--- a/data/points/fans/return-fan-speed.yaml
+++ b/data/points/fans/return-fan-speed.yaml
@@ -34,3 +34,10 @@ aliases:
     - return fan spd
     - return-fan-spd
     - return-fan-speed
+related:
+  - return-fan-alarm
+  - return-fan-command
+  - return-fan-fault
+  - return-fan-feedback
+  - return-fan-output
+  - return-fan-status

--- a/data/points/fans/return-fan-status.yaml
+++ b/data/points/fans/return-fan-status.yaml
@@ -44,3 +44,10 @@ aliases:
     - return fan sts
     - return-fan-sts
     - return-fan-status
+related:
+  - return-fan-alarm
+  - return-fan-command
+  - return-fan-fault
+  - return-fan-feedback
+  - return-fan-output
+  - return-fan-speed

--- a/data/points/fans/supply-fan-alarm.yaml
+++ b/data/points/fans/supply-fan-alarm.yaml
@@ -53,3 +53,10 @@ aliases:
     - supply fan alm
     - supply-fan-alm
     - supply-fan-alarm
+related:
+  - supply-fan-command
+  - supply-fan-fault
+  - supply-fan-feedback
+  - supply-fan-output
+  - supply-fan-speed
+  - supply-fan-status

--- a/data/points/fans/supply-fan-command.yaml
+++ b/data/points/fans/supply-fan-command.yaml
@@ -48,3 +48,10 @@ aliases:
     - sup fan command
     - sup-fan-command
     - supply-fan-command
+related:
+  - supply-fan-alarm
+  - supply-fan-fault
+  - supply-fan-feedback
+  - supply-fan-output
+  - supply-fan-speed
+  - supply-fan-status

--- a/data/points/fans/supply-fan-fault.yaml
+++ b/data/points/fans/supply-fan-fault.yaml
@@ -45,3 +45,10 @@ aliases:
     - sup fan fault
     - sup-fan-fault
     - supply-fan-fault
+related:
+  - supply-fan-alarm
+  - supply-fan-command
+  - supply-fan-feedback
+  - supply-fan-output
+  - supply-fan-speed
+  - supply-fan-status

--- a/data/points/fans/supply-fan-feedback.yaml
+++ b/data/points/fans/supply-fan-feedback.yaml
@@ -40,4 +40,9 @@ aliases:
     - sup-fan-feedback
     - supply-fan-feedback
 related:
+  - supply-fan-alarm
+  - supply-fan-command
+  - supply-fan-fault
   - supply-fan-output
+  - supply-fan-speed
+  - supply-fan-status

--- a/data/points/fans/supply-fan-output.yaml
+++ b/data/points/fans/supply-fan-output.yaml
@@ -39,4 +39,11 @@ aliases:
     - supply-fan-out
     - supply-fan-output
 related:
+  - discharge-air-pressure
+  - duct-static-pressure
+  - supply-fan-alarm
+  - supply-fan-command
+  - supply-fan-fault
   - supply-fan-feedback
+  - supply-fan-speed
+  - supply-fan-status

--- a/data/points/fans/supply-fan-speed.yaml
+++ b/data/points/fans/supply-fan-speed.yaml
@@ -44,5 +44,12 @@ aliases:
     - supply-fan-speed
 
 related:
+  - discharge-air-pressure
   - duct-static-pressure
   - duct-static-pressure-setpoint
+  - supply-fan-alarm
+  - supply-fan-command
+  - supply-fan-fault
+  - supply-fan-feedback
+  - supply-fan-output
+  - supply-fan-status

--- a/data/points/fans/supply-fan-status.yaml
+++ b/data/points/fans/supply-fan-status.yaml
@@ -72,7 +72,9 @@ notes:
   - Should match command within reasonable delay
   - Critical for safety interlocks
 related:
-  - supply-fan-command
   - supply-fan-alarm
+  - supply-fan-command
   - supply-fan-fault
+  - supply-fan-feedback
+  - supply-fan-output
   - supply-fan-speed

--- a/data/points/flows/chilled-water-flow.yaml
+++ b/data/points/flows/chilled-water-flow.yaml
@@ -25,6 +25,7 @@ notes:
   - Low flow with high delta-T may indicate valve or pump issues
 
 related:
-  - chilled-water-supply-temperature
-  - chilled-water-return-temperature
   - chilled-water-differential-pressure
+  - chilled-water-differential-pressure-setpoint
+  - chilled-water-return-temperature
+  - chilled-water-supply-temperature

--- a/data/points/flows/discharge-air-flow.yaml
+++ b/data/points/flows/discharge-air-flow.yaml
@@ -42,3 +42,5 @@ aliases:
     - discharge air flw
     - discharge-air-flw
     - discharge-air-flow
+related:
+  - supply-air-flow

--- a/data/points/flows/exhaust-air-flow.yaml
+++ b/data/points/flows/exhaust-air-flow.yaml
@@ -38,3 +38,7 @@ aliases:
     - exhaust air flw
     - exhaust-air-flw
     - exhaust-air-flow
+related:
+  - exhaust-air-damper-output
+  - exhaust-fan-speed
+  - outdoor-air-flow

--- a/data/points/flows/outdoor-air-flow.yaml
+++ b/data/points/flows/outdoor-air-flow.yaml
@@ -37,6 +37,8 @@ aliases:
     - outdoor-air-flow
 
 related:
-  - minimum-outdoor-airflow-setpoint
-  - zone-co2
   - co2-setpoint
+  - exhaust-air-flow
+  - minimum-outdoor-airflow-setpoint
+  - outside-air-damper-output
+  - zone-co2

--- a/data/points/flows/return-air-flow.yaml
+++ b/data/points/flows/return-air-flow.yaml
@@ -38,3 +38,6 @@ aliases:
     - return air flw
     - return-air-flw
     - return-air-flow
+related:
+  - return-air-temperature
+  - supply-air-flow

--- a/data/points/flows/steam-flow.yaml
+++ b/data/points/flows/steam-flow.yaml
@@ -24,5 +24,6 @@ notes:
   - Used for campus steam billing and boiler plant monitoring
 
 related:
+  - steam-heating-output
   - steam-valve-closed
   - steam-valve-open

--- a/data/points/flows/supply-air-flow.yaml
+++ b/data/points/flows/supply-air-flow.yaml
@@ -38,3 +38,6 @@ aliases:
     - supply air flw
     - supply-air-flw
     - supply-air-flow
+related:
+  - discharge-air-flow
+  - return-air-flow

--- a/data/points/humidity/discharge-air-humidity.yaml
+++ b/data/points/humidity/discharge-air-humidity.yaml
@@ -44,3 +44,5 @@ aliases:
     - discharge air hum
     - discharge-air-hum
     - discharge-air-humidity
+related:
+  - dewpoint-temperature

--- a/data/points/humidity/humidifier-enable.yaml
+++ b/data/points/humidity/humidifier-enable.yaml
@@ -37,3 +37,8 @@ aliases:
     - humidifier en
     - humidifier-en
     - humidifier-enable
+related:
+  - humidifier-feedback
+  - humidifier-output
+  - humidity-setpoint
+  - zone-humidity

--- a/data/points/humidity/humidifier-feedback.yaml
+++ b/data/points/humidity/humidifier-feedback.yaml
@@ -40,4 +40,7 @@ aliases:
     - humidifier-feedback
     - humidifier valve feedback
 related:
+  - humidifier-enable
   - humidifier-output
+  - humidity-setpoint
+  - zone-humidity

--- a/data/points/humidity/humidifier-output.yaml
+++ b/data/points/humidity/humidifier-output.yaml
@@ -49,4 +49,7 @@ aliases:
     - humidifier-output
     - humidifier valve out
 related:
+  - humidifier-enable
   - humidifier-feedback
+  - humidity-setpoint
+  - zone-humidity

--- a/data/points/humidity/outdoor-air-humidity.yaml
+++ b/data/points/humidity/outdoor-air-humidity.yaml
@@ -44,3 +44,8 @@ aliases:
     - outdoor-air-hum
     - outdoor air humid
     - outdoor-air-humidity
+related:
+  - outdoor-air-temperature
+  - return-air-humidity
+  - wet-bulb-temperature
+  - zone-humidity

--- a/data/points/humidity/return-air-humidity.yaml
+++ b/data/points/humidity/return-air-humidity.yaml
@@ -45,3 +45,7 @@ aliases:
     - ret air humidity
     - ret-air-humidity
     - return-air-humidity
+related:
+  - humidity-setpoint
+  - outdoor-air-humidity
+  - zone-humidity

--- a/data/points/humidity/zone-humidity.yaml
+++ b/data/points/humidity/zone-humidity.yaml
@@ -37,4 +37,10 @@ aliases:
     - zone-humidity
 
 related:
+  - dewpoint-temperature
+  - humidifier-enable
+  - humidifier-feedback
+  - humidifier-output
   - humidity-setpoint
+  - outdoor-air-humidity
+  - return-air-humidity

--- a/data/points/iaq/co2-setpoint.yaml
+++ b/data/points/iaq/co2-setpoint.yaml
@@ -24,6 +24,8 @@ notes:
   - Lower setpoints increase ventilation energy but improve IAQ
 
 related:
-  - zone-co2
+  - minimum-outdoor-airflow-setpoint
   - outdoor-air-co2
   - outdoor-air-flow
+  - return-air-co2
+  - zone-co2

--- a/data/points/iaq/particulate-matter-pm10.yaml
+++ b/data/points/iaq/particulate-matter-pm10.yaml
@@ -23,3 +23,4 @@ notes:
 
 related:
   - particulate-matter-pm25
+  - volatile-organic-compounds

--- a/data/points/iaq/particulate-matter-pm25.yaml
+++ b/data/points/iaq/particulate-matter-pm25.yaml
@@ -27,4 +27,4 @@ notes:
 
 related:
   - particulate-matter-pm10
-  - outdoor-air-quality-index
+  - volatile-organic-compounds

--- a/data/points/iaq/volatile-organic-compounds.yaml
+++ b/data/points/iaq/volatile-organic-compounds.yaml
@@ -26,5 +26,6 @@ notes:
   - Can trigger increased ventilation or filtration when levels are elevated
 
 related:
-  - zone-co2
+  - particulate-matter-pm10
   - particulate-matter-pm25
+  - zone-co2

--- a/data/points/iaq/zone-co2.yaml
+++ b/data/points/iaq/zone-co2.yaml
@@ -30,6 +30,8 @@ notes:
 
 related:
   - co2-setpoint
+  - minimum-outdoor-airflow-setpoint
   - outdoor-air-co2
   - outdoor-air-flow
   - return-air-co2
+  - volatile-organic-compounds

--- a/data/points/lighting/daylight-illuminance.yaml
+++ b/data/points/lighting/daylight-illuminance.yaml
@@ -28,5 +28,6 @@ notes:
   - Used to modulate electric lighting in daylight harvesting sequences
 
 related:
-  - lighting-level
   - lighting-dimming-output
+  - lighting-level
+  - lighting-occupancy-sensor

--- a/data/points/lighting/lighting-occupancy-sensor.yaml
+++ b/data/points/lighting/lighting-occupancy-sensor.yaml
@@ -34,6 +34,7 @@ notes:
   - Timeout period is configurable (typically 15-30 minutes)
 
 related:
-  - lighting-level
+  - daylight-illuminance
   - lighting-dimming-output
+  - lighting-level
   - occupancy

--- a/data/points/maintenance/equipment-start-count.yaml
+++ b/data/points/maintenance/equipment-start-count.yaml
@@ -26,3 +26,4 @@ notes:
 
 related:
   - equipment-run-hours
+  - run-time

--- a/data/points/pressures/building-pressure.yaml
+++ b/data/points/pressures/building-pressure.yaml
@@ -36,3 +36,5 @@ aliases:
 
 related:
   - building-pressure-setpoint
+  - exhaust-air-damper-output
+  - relief-air-damper-output

--- a/data/points/pressures/chilled-water-differential-pressure.yaml
+++ b/data/points/pressures/chilled-water-differential-pressure.yaml
@@ -42,3 +42,7 @@ aliases:
     - chilled-water-differential-pressure
     - chw-diff
     - chw-delta-p
+related:
+  - chilled-water-differential-pressure-setpoint
+  - chilled-water-flow
+  - hot-water-differential-pressure

--- a/data/points/pressures/discharge-air-high-pressure-alarm.yaml
+++ b/data/points/pressures/discharge-air-high-pressure-alarm.yaml
@@ -58,3 +58,6 @@ aliases:
     - discharge air high pressure alm
     - discharge-air-high-pressure-alm
     - discharge-air-high-pressure-alarm
+related:
+  - discharge-air-low-pressure-alarm
+  - discharge-air-pressure

--- a/data/points/pressures/discharge-air-low-pressure-alarm.yaml
+++ b/data/points/pressures/discharge-air-low-pressure-alarm.yaml
@@ -58,3 +58,6 @@ aliases:
     - discharge air low pressure alm
     - discharge-air-low-pressure-alm
     - discharge-air-low-pressure-alarm
+related:
+  - discharge-air-high-pressure-alarm
+  - discharge-air-pressure

--- a/data/points/pressures/discharge-air-pressure.yaml
+++ b/data/points/pressures/discharge-air-pressure.yaml
@@ -93,7 +93,10 @@ notes:
   - Setpoint typically 1.0-2.0 in.wc for VAV systems
   - Higher setpoint needed for longer duct runs
 related:
+  - discharge-air-high-pressure-alarm
+  - discharge-air-low-pressure-alarm
   - discharge-air-pressure-setpoint
-  - supply-fan-speed
-  - supply-fan-output
+  - duct-static-pressure
   - duct-static-pressure-setpoint
+  - supply-fan-output
+  - supply-fan-speed

--- a/data/points/pressures/duct-static-pressure.yaml
+++ b/data/points/pressures/duct-static-pressure.yaml
@@ -30,5 +30,6 @@ notes:
 related:
   - discharge-air-pressure
   - discharge-air-pressure-setpoint
-  - supply-fan-speed
+  - duct-static-pressure-setpoint
   - supply-fan-output
+  - supply-fan-speed

--- a/data/points/pressures/filter-differential-pressure.yaml
+++ b/data/points/pressures/filter-differential-pressure.yaml
@@ -29,5 +29,7 @@ notes:
 related:
   - filter-alarm
   - filter-status
-  - prefilter-alarm
   - final-filter-alarm
+  - final-filter-status
+  - prefilter-alarm
+  - prefilter-status

--- a/data/points/pressures/hot-water-differential-pressure.yaml
+++ b/data/points/pressures/hot-water-differential-pressure.yaml
@@ -41,3 +41,6 @@ aliases:
     - hot-water-differential-pressure
     - hw-diff
     - hw-delta-p
+related:
+  - chilled-water-differential-pressure
+  - hot-water-flow

--- a/data/points/pressures/return-air-high-pressure-alarm.yaml
+++ b/data/points/pressures/return-air-high-pressure-alarm.yaml
@@ -55,3 +55,6 @@ aliases:
     - return air high pressure alm
     - return-air-high-pressure-alm
     - return-air-high-pressure-alarm
+related:
+  - return-air-low-pressure-alarm
+  - return-air-pressure

--- a/data/points/pressures/return-air-low-pressure-alarm.yaml
+++ b/data/points/pressures/return-air-low-pressure-alarm.yaml
@@ -55,3 +55,6 @@ aliases:
     - return air low pressure alm
     - return-air-low-pressure-alm
     - return-air-low-pressure-alarm
+related:
+  - return-air-high-pressure-alarm
+  - return-air-pressure

--- a/data/points/pressures/return-air-pressure.yaml
+++ b/data/points/pressures/return-air-pressure.yaml
@@ -42,3 +42,7 @@ aliases:
     - return air press
     - return-air-press
     - return-air-pressure
+related:
+  - return-air-high-pressure-alarm
+  - return-air-low-pressure-alarm
+  - return-air-pressure-setpoint

--- a/data/points/pressures/space-pressure.yaml
+++ b/data/points/pressures/space-pressure.yaml
@@ -72,3 +72,5 @@ aliases:
     - room pressure
     - zone pressure
     - space-pressure
+related:
+  - building-pressure-setpoint

--- a/data/points/setpoints/building-pressure-setpoint.yaml
+++ b/data/points/setpoints/building-pressure-setpoint.yaml
@@ -26,5 +26,6 @@ notes:
 
 related:
   - building-pressure
-  - space-pressure
   - relief-air-damper-position
+  - return-air-pressure-setpoint
+  - space-pressure

--- a/data/points/setpoints/cooling-outdoor-air-lockout-setpoint.yaml
+++ b/data/points/setpoints/cooling-outdoor-air-lockout-setpoint.yaml
@@ -44,3 +44,6 @@ aliases:
     - clg outdoor air lockout setpoint
     - clg-outdoor-air-lockout-setpoint
     - cooling-outdoor-air-lockout-setpoint
+related:
+  - outdoor-air-temperature
+  - zone-temperature

--- a/data/points/setpoints/discharge-air-pressure-setpoint.yaml
+++ b/data/points/setpoints/discharge-air-pressure-setpoint.yaml
@@ -59,3 +59,7 @@ aliases:
     - dap-setpoint
     - duct-pressure-sp
     - static-pressure-sp
+related:
+  - discharge-air-pressure
+  - duct-static-pressure
+  - duct-static-pressure-setpoint

--- a/data/points/setpoints/discharge-air-temperature-setpoint.yaml
+++ b/data/points/setpoints/discharge-air-temperature-setpoint.yaml
@@ -36,3 +36,6 @@ aliases:
     - discharge-air-temperature-setpoint
     - dat-setpoint
     - da-temp-sp
+related:
+  - discharge-air-temperature
+  - effective-discharge-air-temperature-setpoint

--- a/data/points/setpoints/duct-static-pressure-setpoint.yaml
+++ b/data/points/setpoints/duct-static-pressure-setpoint.yaml
@@ -26,6 +26,7 @@ notes:
   - Static pressure reset can save 20-40% of fan energy
 
 related:
-  - duct-static-pressure
+  - discharge-air-pressure
   - discharge-air-pressure-setpoint
+  - duct-static-pressure
   - supply-fan-speed

--- a/data/points/setpoints/effective-cooling-setpoint.yaml
+++ b/data/points/setpoints/effective-cooling-setpoint.yaml
@@ -39,3 +39,8 @@ aliases:
     - effective cooling sp
     - effective-cooling-sp
     - effective-cooling-setpoint
+related:
+  - effective-heating-setpoint
+  - occupied-cooling-setpoint
+  - standby-cooling-setpoint
+  - zone-temperature

--- a/data/points/setpoints/effective-discharge-air-temperature-setpoint.yaml
+++ b/data/points/setpoints/effective-discharge-air-temperature-setpoint.yaml
@@ -46,3 +46,6 @@ aliases:
     - effective discharge air temperature sp
     - effective-discharge-air-temperature-sp
     - effective-discharge-air-temperature-setpoint
+related:
+  - discharge-air-temperature
+  - discharge-air-temperature-setpoint

--- a/data/points/setpoints/effective-heating-setpoint.yaml
+++ b/data/points/setpoints/effective-heating-setpoint.yaml
@@ -39,3 +39,8 @@ aliases:
     - effective heating sp
     - effective-heating-sp
     - effective-heating-setpoint
+related:
+  - effective-cooling-setpoint
+  - occupied-heating-setpoint
+  - standby-heating-setpoint
+  - zone-temperature

--- a/data/points/setpoints/heating-outdoor-air-lockout-setpoint.yaml
+++ b/data/points/setpoints/heating-outdoor-air-lockout-setpoint.yaml
@@ -48,3 +48,5 @@ aliases:
     - htg outdoor air lockout setpoint
     - htg-outdoor-air-lockout-setpoint
     - heating-outdoor-air-lockout-setpoint
+related:
+  - outdoor-air-temperature

--- a/data/points/setpoints/humidity-setpoint.yaml
+++ b/data/points/setpoints/humidity-setpoint.yaml
@@ -26,6 +26,9 @@ notes:
   - Some systems use separate high-limit and low-limit humidity setpoints
 
 related:
-  - zone-humidity
+  - dewpoint-temperature
   - humidifier-enable
+  - humidifier-feedback
   - humidifier-output
+  - return-air-humidity
+  - zone-humidity

--- a/data/points/setpoints/minimum-outdoor-airflow-setpoint.yaml
+++ b/data/points/setpoints/minimum-outdoor-airflow-setpoint.yaml
@@ -27,6 +27,7 @@ notes:
   - In DCV mode, this setpoint may vary with occupancy count or CO2 levels
 
 related:
-  - outdoor-air-flow
-  - zone-co2
   - co2-setpoint
+  - outdoor-air-flow
+  - outside-air-damper-output
+  - zone-co2

--- a/data/points/setpoints/mixed-air-temperature-setpoint.yaml
+++ b/data/points/setpoints/mixed-air-temperature-setpoint.yaml
@@ -51,3 +51,5 @@ aliases:
     - ma air temperature setpoint
     - ma-air-temperature-setpoint
     - mixed-air-temperature-setpoint
+related:
+  - mixed-air-temperature

--- a/data/points/setpoints/occupied-cooling-setpoint.yaml
+++ b/data/points/setpoints/occupied-cooling-setpoint.yaml
@@ -54,3 +54,10 @@ aliases:
     - occ-cooling-setpoint
     - occupied-cooling-setpoint
     - occupied-clg-sp
+related:
+  - cooling-enable
+  - effective-cooling-setpoint
+  - occupied-heating-setpoint
+  - standby-cooling-setpoint
+  - unoccupied-cooling-setpoint
+  - zone-temperature

--- a/data/points/setpoints/occupied-heating-setpoint.yaml
+++ b/data/points/setpoints/occupied-heating-setpoint.yaml
@@ -54,3 +54,10 @@ aliases:
     - occ-heating-setpoint
     - occupied-heating-setpoint
     - occupied-htg-sp
+related:
+  - effective-heating-setpoint
+  - heating-enable
+  - occupied-cooling-setpoint
+  - standby-heating-setpoint
+  - unoccupied-heating-setpoint
+  - zone-temperature

--- a/data/points/setpoints/return-air-pressure-setpoint.yaml
+++ b/data/points/setpoints/return-air-pressure-setpoint.yaml
@@ -53,3 +53,6 @@ aliases:
     - ret air pressure setpoint
     - ret-air-pressure-setpoint
     - return-air-pressure-setpoint
+related:
+  - building-pressure-setpoint
+  - return-air-pressure

--- a/data/points/setpoints/standby-cooling-setpoint.yaml
+++ b/data/points/setpoints/standby-cooling-setpoint.yaml
@@ -46,3 +46,7 @@ aliases:
     - stby cooling setpoint
     - stby-cooling-setpoint
     - standby-cooling-setpoint
+related:
+  - effective-cooling-setpoint
+  - occupied-cooling-setpoint
+  - unoccupied-cooling-setpoint

--- a/data/points/setpoints/standby-heating-setpoint.yaml
+++ b/data/points/setpoints/standby-heating-setpoint.yaml
@@ -46,3 +46,7 @@ aliases:
     - stby heating setpoint
     - stby-heating-setpoint
     - standby-heating-setpoint
+related:
+  - effective-heating-setpoint
+  - occupied-heating-setpoint
+  - unoccupied-heating-setpoint

--- a/data/points/setpoints/unoccupied-cooling-setpoint.yaml
+++ b/data/points/setpoints/unoccupied-cooling-setpoint.yaml
@@ -54,3 +54,8 @@ aliases:
     - unocc-cooling-setpoint
     - unoccupied-cooling-setpoint
     - unoccupied-clg-sp
+related:
+  - occupied-cooling-setpoint
+  - standby-cooling-setpoint
+  - unoccupied-heating-setpoint
+  - zone-temperature

--- a/data/points/setpoints/unoccupied-heating-setpoint.yaml
+++ b/data/points/setpoints/unoccupied-heating-setpoint.yaml
@@ -54,3 +54,8 @@ aliases:
     - unocc-heating-setpoint
     - unoccupied-heating-setpoint
     - unoccupied-htg-sp
+related:
+  - occupied-heating-setpoint
+  - standby-heating-setpoint
+  - unoccupied-cooling-setpoint
+  - zone-temperature

--- a/data/points/setpoints/zone-temperature-setpoint.yaml
+++ b/data/points/setpoints/zone-temperature-setpoint.yaml
@@ -23,3 +23,5 @@ aliases:
     - ZAT-SP
     - room-temp-sp
     - space-temp-sp
+related:
+  - zone-temperature

--- a/data/points/status/boiler-pump-status.yaml
+++ b/data/points/status/boiler-pump-status.yaml
@@ -54,3 +54,8 @@ aliases:
     - boiler pump sts
     - boiler-pump-sts
     - boiler-pump-status
+related:
+  - boiler-pump-alarm
+  - boiler-pump-command
+  - boiler-pump-feedback
+  - boiler-pump-output

--- a/data/points/status/boiler-status.yaml
+++ b/data/points/status/boiler-status.yaml
@@ -67,3 +67,8 @@ aliases:
     - boiler-status
     - boiler running
     - boiler run status
+related:
+  - boiler-alarm
+  - boiler-command
+  - boiler-feedback
+  - boiler-output

--- a/data/points/status/chilled-water-pump-status.yaml
+++ b/data/points/status/chilled-water-pump-status.yaml
@@ -47,3 +47,8 @@ aliases:
     - chilled water pump sts
     - chilled-water-pump-sts
     - chilled-water-pump-status
+related:
+  - chilled-water-pump-alarm
+  - chilled-water-pump-command
+  - chilled-water-pump-feedback
+  - chilled-water-pump-output

--- a/data/points/status/chiller-status.yaml
+++ b/data/points/status/chiller-status.yaml
@@ -73,3 +73,7 @@ aliases:
     - chiller-status
     - chiller running
     - chiller run status
+related:
+  - chiller-alarm
+  - chiller-command
+  - chiller-enable

--- a/data/points/status/condenser-water-pump-status.yaml
+++ b/data/points/status/condenser-water-pump-status.yaml
@@ -46,3 +46,8 @@ aliases:
     - condenser water pump sts
     - condenser-water-pump-sts
     - condenser-water-pump-status
+related:
+  - condenser-water-pump-alarm
+  - condenser-water-pump-command
+  - condenser-water-pump-feedback
+  - condenser-water-pump-output

--- a/data/points/status/cooling-tower-status.yaml
+++ b/data/points/status/cooling-tower-status.yaml
@@ -73,3 +73,9 @@ aliases:
     - cooling-tower-sts
     - cooling-tower-status
     - cooling tower running
+related:
+  - cooling-tower-alarm
+  - cooling-tower-command
+  - cooling-tower-enable
+  - cooling-tower-feedback
+  - cooling-tower-output

--- a/data/points/status/dx-cooling-stage.yaml
+++ b/data/points/status/dx-cooling-stage.yaml
@@ -71,3 +71,7 @@ aliases:
     - compressor-stge
     - compressor stage
     - dx-cooling-stage
+related:
+  - cooling-enable
+  - discharge-air-temperature
+  - zone-temperature

--- a/data/points/status/effective-occupancy.yaml
+++ b/data/points/status/effective-occupancy.yaml
@@ -32,3 +32,7 @@ aliases:
     - effectiveoccupancy
     - effective-occupancy
     - current-occupancy
+related:
+  - occupancy
+  - occupancy-schedule
+  - occupied-command

--- a/data/points/status/electric-heat-stage.yaml
+++ b/data/points/status/electric-heat-stage.yaml
@@ -63,3 +63,7 @@ aliases:
     - electric-heat-stg
     - electric-heat-stage
     - electric heating stage
+related:
+  - discharge-air-temperature
+  - heating-enable
+  - zone-temperature

--- a/data/points/status/filter-status.yaml
+++ b/data/points/status/filter-status.yaml
@@ -45,4 +45,7 @@ aliases:
     - filter-status
 
 related:
+  - filter-alarm
   - filter-differential-pressure
+  - final-filter-status
+  - prefilter-status

--- a/data/points/status/final-filter-status.yaml
+++ b/data/points/status/final-filter-status.yaml
@@ -50,3 +50,7 @@ aliases:
     - final-filter-sts
     - fin filter status
     - final-filter-status
+related:
+  - filter-differential-pressure
+  - filter-status
+  - final-filter-alarm

--- a/data/points/status/heat-wheel-status.yaml
+++ b/data/points/status/heat-wheel-status.yaml
@@ -64,3 +64,7 @@ aliases:
     - nrg recovery whl sts
     - nrg-recovery-whl-sts
     - energy recovery wheel status
+related:
+  - heat-wheel-command
+  - heat-wheel-feedback
+  - heat-wheel-output

--- a/data/points/status/hot-water-pump-status.yaml
+++ b/data/points/status/hot-water-pump-status.yaml
@@ -46,3 +46,8 @@ aliases:
     - ht water pump status
     - ht-water-pump-status
     - hot-water-pump-status
+related:
+  - hot-water-pump-alarm
+  - hot-water-pump-command
+  - hot-water-pump-feedback
+  - hot-water-pump-output

--- a/data/points/status/occupancy-schedule.yaml
+++ b/data/points/status/occupancy-schedule.yaml
@@ -29,3 +29,7 @@ aliases:
     - occupancyschedule
     - occupancy schedule
     - occupancy-schedule
+related:
+  - effective-occupancy
+  - occupancy
+  - occupied-command

--- a/data/points/status/occupancy.yaml
+++ b/data/points/status/occupancy.yaml
@@ -21,3 +21,8 @@ aliases:
   common:
     - occupied
     - occ
+related:
+  - effective-occupancy
+  - lighting-occupancy-sensor
+  - occupancy-schedule
+  - occupied-command

--- a/data/points/status/prefilter-status.yaml
+++ b/data/points/status/prefilter-status.yaml
@@ -48,3 +48,7 @@ aliases:
     - pre filt status
     - prefilter-status
     - pre filter status
+related:
+  - filter-differential-pressure
+  - filter-status
+  - prefilter-alarm

--- a/data/points/status/primary-chilled-water-pump-status.yaml
+++ b/data/points/status/primary-chilled-water-pump-status.yaml
@@ -45,3 +45,8 @@ aliases:
     - primary chilled water pump sts
     - primary-chilled-water-pump-sts
     - primary-chilled-water-pump-status
+related:
+  - primary-chilled-water-pump-alarm
+  - primary-chilled-water-pump-command
+  - primary-chilled-water-pump-feedback
+  - primary-chilled-water-pump-output

--- a/data/points/status/return-air-co2.yaml
+++ b/data/points/status/return-air-co2.yaml
@@ -51,5 +51,6 @@ aliases:
     - co2
 
 related:
-  - zone-co2
   - co2-setpoint
+  - outdoor-air-co2
+  - zone-co2

--- a/data/points/status/secondary-chilled-water-pump-status.yaml
+++ b/data/points/status/secondary-chilled-water-pump-status.yaml
@@ -45,3 +45,8 @@ aliases:
     - secondary chilled water pump sts
     - secondary-chilled-water-pump-sts
     - secondary-chilled-water-pump-status
+related:
+  - secondary-chilled-water-pump-alarm
+  - secondary-chilled-water-pump-command
+  - secondary-chilled-water-pump-feedback
+  - secondary-chilled-water-pump-output

--- a/data/points/status/shutdown.yaml
+++ b/data/points/status/shutdown.yaml
@@ -9,3 +9,5 @@ concept:
 aliases:
   common:
     - shutdwn
+related:
+  - system-enable

--- a/data/points/temperatures/chilled-water-return-temperature.yaml
+++ b/data/points/temperatures/chilled-water-return-temperature.yaml
@@ -42,5 +42,8 @@ aliases:
     - chw-return-temp
 
 related:
-  - chilled-water-supply-temperature-setpoint
   - chilled-water-flow
+  - chilled-water-supply-temperature
+  - chilled-water-supply-temperature-setpoint
+  - chiller-entering-temperature
+  - chiller-leaving-temperature

--- a/data/points/temperatures/chilled-water-supply-temperature.yaml
+++ b/data/points/temperatures/chilled-water-supply-temperature.yaml
@@ -56,8 +56,11 @@ notes:
   - Must stay above 40°F to prevent coil freezing
   - Delta T from return typically 10-14°F
 related:
-  - chilled-water-return-temperature
-  - chiller-1-leaving-temperature
-  - cooling-valve-output
-  - chilled-water-supply-temperature-setpoint
   - chilled-water-flow
+  - chilled-water-return-temperature
+  - chilled-water-supply-temperature-setpoint
+  - chiller-entering-temperature
+  - chiller-leaving-temperature
+  - cooling-valve-output
+  - primary-chilled-water-supply-temperature
+  - secondary-chilled-water-supply-temperature

--- a/data/points/temperatures/chiller-entering-temperature.yaml
+++ b/data/points/temperatures/chiller-entering-temperature.yaml
@@ -78,3 +78,7 @@ aliases:
     - chl-entering-temperature
     - chiller entering water temp
     - chiller-entering-temperature
+related:
+  - chilled-water-return-temperature
+  - chilled-water-supply-temperature
+  - chiller-leaving-temperature

--- a/data/points/temperatures/chiller-leaving-temperature.yaml
+++ b/data/points/temperatures/chiller-leaving-temperature.yaml
@@ -67,3 +67,7 @@ aliases:
     - chl-leaving-temperature
     - chiller leaving water temp
     - chiller-leaving-temperature
+related:
+  - chilled-water-return-temperature
+  - chilled-water-supply-temperature
+  - chiller-entering-temperature

--- a/data/points/temperatures/city-water-temperature.yaml
+++ b/data/points/temperatures/city-water-temperature.yaml
@@ -29,3 +29,5 @@ aliases:
     - city wtr temperature
     - city-wtr-temperature
     - city-water-temperature
+related:
+  - domestic-hot-water-supply-temperature

--- a/data/points/temperatures/condenser-water-return-temperature.yaml
+++ b/data/points/temperatures/condenser-water-return-temperature.yaml
@@ -41,5 +41,7 @@ aliases:
     - cw-return-temp
 
 related:
-  - condenser-water-supply-temperature-setpoint
   - condenser-water-flow
+  - condenser-water-supply-temperature
+  - condenser-water-supply-temperature-setpoint
+  - cooling-tower-basin-temperature

--- a/data/points/temperatures/condenser-water-supply-temperature.yaml
+++ b/data/points/temperatures/condenser-water-supply-temperature.yaml
@@ -41,5 +41,8 @@ aliases:
     - cw-supply-temp
 
 related:
-  - condenser-water-supply-temperature-setpoint
   - condenser-water-flow
+  - condenser-water-return-temperature
+  - condenser-water-supply-temperature-setpoint
+  - cooling-tower-basin-temperature
+  - wet-bulb-temperature

--- a/data/points/temperatures/cooling-tower-basin-temperature.yaml
+++ b/data/points/temperatures/cooling-tower-basin-temperature.yaml
@@ -85,3 +85,7 @@ aliases:
     - clg tower basin temperature
     - clg-tower-basin-temperature
     - cooling-tower-basin-temperature
+related:
+  - condenser-water-return-temperature
+  - condenser-water-supply-temperature
+  - wet-bulb-temperature

--- a/data/points/temperatures/dewpoint-temperature.yaml
+++ b/data/points/temperatures/dewpoint-temperature.yaml
@@ -28,6 +28,8 @@ notes:
   - Can be calculated from dry bulb temperature and relative humidity
 
 related:
-  - zone-humidity
   - discharge-air-humidity
   - humidity-setpoint
+  - outdoor-air-temperature
+  - wet-bulb-temperature
+  - zone-humidity

--- a/data/points/temperatures/discharge-air-temperature.yaml
+++ b/data/points/temperatures/discharge-air-temperature.yaml
@@ -51,8 +51,14 @@ notes:
   - Sometimes called Supply Air Temperature (SAT) downstream of unit
   - Critical for discharge air temperature control loops
 related:
-  - supply-air-temperature
-  - mixed-air-temperature
-  - discharge-air-temperature-setpoint
   - cooling-valve-output
+  - discharge-air-temperature-setpoint
+  - dx-cooling-stage
+  - effective-discharge-air-temperature-setpoint
+  - electric-heat-stage
   - heating-valve-output
+  - low-limit-alarm
+  - mixed-air-temperature
+  - return-air-temperature
+  - supply-air-temperature
+  - zone-temperature

--- a/data/points/temperatures/domestic-hot-water-return-temperature.yaml
+++ b/data/points/temperatures/domestic-hot-water-return-temperature.yaml
@@ -34,3 +34,5 @@ aliases:
     - domestic hot water return temp
     - domestic-hot-water-return-temp
     - domestic-hot-water-return-temperature
+related:
+  - domestic-hot-water-supply-temperature

--- a/data/points/temperatures/domestic-hot-water-supply-temperature.yaml
+++ b/data/points/temperatures/domestic-hot-water-supply-temperature.yaml
@@ -34,3 +34,6 @@ aliases:
     - domestic hot water supply temp
     - domestic-hot-water-supply-temp
     - domestic-hot-water-supply-temperature
+related:
+  - city-water-temperature
+  - domestic-hot-water-return-temperature

--- a/data/points/temperatures/exhaust-air-temperature.yaml
+++ b/data/points/temperatures/exhaust-air-temperature.yaml
@@ -1,8 +1,8 @@
 concept:
-  id: exhaust-air-temperaure
-  name: Exhaust Air Temperaure
+  id: exhaust-air-temperature
+  name: Exhaust Air Temperature
   category: temperatures
-  description: Exhaust Air Temperaure point
+  description: Exhaust Air Temperature point
   haystack: exhaust air temp sensor
   brick: Exhaust_Air_Temperature_Sensor
   point_function: sensor
@@ -40,3 +40,6 @@ aliases:
     - exh air temperaure
     - exh-air-temperaure
     - exhaust-air-temperaure
+    - exhaust-air-temperature
+related:
+  - outdoor-air-temperature

--- a/data/points/temperatures/hot-water-return-temperature.yaml
+++ b/data/points/temperatures/hot-water-return-temperature.yaml
@@ -41,5 +41,6 @@ aliases:
     - hw-return-temp
 
 related:
-  - hot-water-supply-temperature-setpoint
   - hot-water-flow
+  - hot-water-supply-temperature
+  - hot-water-supply-temperature-setpoint

--- a/data/points/temperatures/hot-water-supply-temperature.yaml
+++ b/data/points/temperatures/hot-water-supply-temperature.yaml
@@ -41,5 +41,8 @@ aliases:
     - hw-supply-temp
 
 related:
-  - hot-water-supply-temperature-setpoint
   - hot-water-flow
+  - hot-water-return-temperature
+  - hot-water-supply-temperature-setpoint
+  - primary-hot-water-supply-temperature
+  - secondary-hot-water-supply-temperature

--- a/data/points/temperatures/mixed-air-temperature.yaml
+++ b/data/points/temperatures/mixed-air-temperature.yaml
@@ -37,3 +37,10 @@ aliases:
     - ma-air-temperature
     - mixed-air-temperature
     - mixed-temp
+related:
+  - discharge-air-temperature
+  - low-limit-alarm
+  - mixed-air-temperature-setpoint
+  - outdoor-air-temperature
+  - return-air-temperature
+  - supply-air-temperature

--- a/data/points/temperatures/outdoor-air-temperature.yaml
+++ b/data/points/temperatures/outdoor-air-temperature.yaml
@@ -56,7 +56,12 @@ notes:
   - Often shared across multiple AHUs via BACnet
   - May be provided by weather service in some systems
 related:
-  - economizer-enable
   - cooling-outdoor-air-lockout-setpoint
+  - dewpoint-temperature
+  - economizer-enable
+  - exhaust-air-temperature
   - heating-outdoor-air-lockout-setpoint
+  - mixed-air-temperature
   - outdoor-air-humidity
+  - outside-air-damper-output
+  - wet-bulb-temperature

--- a/data/points/temperatures/primary-chilled-water-return-temperature.yaml
+++ b/data/points/temperatures/primary-chilled-water-return-temperature.yaml
@@ -37,3 +37,5 @@ aliases:
     - pri chilled water return temperature
     - pri-chilled-water-return-temperature
     - primary-chilled-water-return-temperature
+related:
+  - primary-chilled-water-supply-temperature

--- a/data/points/temperatures/primary-chilled-water-supply-temperature.yaml
+++ b/data/points/temperatures/primary-chilled-water-supply-temperature.yaml
@@ -37,3 +37,6 @@ aliases:
     - pri chilled water supply temperature
     - pri-chilled-water-supply-temperature
     - primary-chilled-water-supply-temperature
+related:
+  - chilled-water-supply-temperature
+  - primary-chilled-water-return-temperature

--- a/data/points/temperatures/primary-hot-water-return-temperature.yaml
+++ b/data/points/temperatures/primary-hot-water-return-temperature.yaml
@@ -36,3 +36,5 @@ aliases:
     - pri hot water return temperature
     - pri-hot-water-return-temperature
     - primary-hot-water-return-temperature
+related:
+  - primary-hot-water-supply-temperature

--- a/data/points/temperatures/primary-hot-water-supply-temperature.yaml
+++ b/data/points/temperatures/primary-hot-water-supply-temperature.yaml
@@ -36,3 +36,6 @@ aliases:
     - pri hot water supply temperature
     - pri-hot-water-supply-temperature
     - primary-hot-water-supply-temperature
+related:
+  - hot-water-supply-temperature
+  - primary-hot-water-return-temperature

--- a/data/points/temperatures/return-air-temperature.yaml
+++ b/data/points/temperatures/return-air-temperature.yaml
@@ -41,3 +41,9 @@ aliases:
     - ret-air-temperature
     - return-air-temperature
     - return-temp
+related:
+  - discharge-air-temperature
+  - mixed-air-temperature
+  - return-air-flow
+  - supply-air-temperature
+  - zone-temperature

--- a/data/points/temperatures/secondary-chilled-water-return-temperature.yaml
+++ b/data/points/temperatures/secondary-chilled-water-return-temperature.yaml
@@ -37,3 +37,5 @@ aliases:
     - sec chilled water return temperature
     - sec-chilled-water-return-temperature
     - secondary-chilled-water-return-temperature
+related:
+  - secondary-chilled-water-supply-temperature

--- a/data/points/temperatures/secondary-chilled-water-supply-temperature.yaml
+++ b/data/points/temperatures/secondary-chilled-water-supply-temperature.yaml
@@ -37,3 +37,6 @@ aliases:
     - sec chilled water supply temperature
     - sec-chilled-water-supply-temperature
     - secondary-chilled-water-supply-temperature
+related:
+  - chilled-water-supply-temperature
+  - secondary-chilled-water-return-temperature

--- a/data/points/temperatures/secondary-hot-water-return-temperature.yaml
+++ b/data/points/temperatures/secondary-hot-water-return-temperature.yaml
@@ -36,3 +36,5 @@ aliases:
     - sec hot water return temperature
     - sec-hot-water-return-temperature
     - secondary-hot-water-return-temperature
+related:
+  - secondary-hot-water-supply-temperature

--- a/data/points/temperatures/secondary-hot-water-supply-temperature.yaml
+++ b/data/points/temperatures/secondary-hot-water-supply-temperature.yaml
@@ -36,3 +36,6 @@ aliases:
     - sec hot water supply temperature
     - sec-hot-water-supply-temperature
     - secondary-hot-water-supply-temperature
+related:
+  - hot-water-supply-temperature
+  - secondary-hot-water-return-temperature

--- a/data/points/temperatures/supply-air-temperature.yaml
+++ b/data/points/temperatures/supply-air-temperature.yaml
@@ -41,3 +41,7 @@ aliases:
     - sup-air-temperature
     - supply-air-temperature
     - supply-temp
+related:
+  - discharge-air-temperature
+  - mixed-air-temperature
+  - return-air-temperature

--- a/data/points/temperatures/wet-bulb-temperature.yaml
+++ b/data/points/temperatures/wet-bulb-temperature.yaml
@@ -27,7 +27,8 @@ notes:
   - Critical for free cooling / waterside economizer calculations
 
 related:
-  - outdoor-air-temperature
-  - outdoor-air-humidity
-  - cooling-tower-basin-temperature
   - condenser-water-supply-temperature
+  - cooling-tower-basin-temperature
+  - dewpoint-temperature
+  - outdoor-air-humidity
+  - outdoor-air-temperature

--- a/data/points/temperatures/zone-temperature.yaml
+++ b/data/points/temperatures/zone-temperature.yaml
@@ -76,7 +76,17 @@ notes:
   - Wireless sensors often use vendor-specific names like EnOcean_Temp_1
   - When multiple sensors in zone, often suffixed ZoneTemp_1, ZoneTemp_Avg
 related:
+  - cooling-outdoor-air-lockout-setpoint
+  - cooling-valve-output
   - discharge-air-temperature
-  - return-air-temperature
+  - dx-cooling-stage
+  - effective-cooling-setpoint
+  - effective-heating-setpoint
+  - electric-heat-stage
+  - heating-valve-output
   - occupied-cooling-setpoint
   - occupied-heating-setpoint
+  - return-air-temperature
+  - unoccupied-cooling-setpoint
+  - unoccupied-heating-setpoint
+  - zone-temperature-setpoint

--- a/data/points/valves/bypass-valve-closed.yaml
+++ b/data/points/valves/bypass-valve-closed.yaml
@@ -28,3 +28,7 @@ aliases:
     - byp-vlv-cl
     - byp vlv cld
     - byp-vlv-cld
+related:
+  - bypass-valve-feedback
+  - bypass-valve-open
+  - bypass-valve-output

--- a/data/points/valves/bypass-valve-feedback.yaml
+++ b/data/points/valves/bypass-valve-feedback.yaml
@@ -36,4 +36,6 @@ aliases:
     - bypass vlv feedback
     - bypass-valve-feedback
 related:
+  - bypass-valve-closed
+  - bypass-valve-open
   - bypass-valve-output

--- a/data/points/valves/bypass-valve-open.yaml
+++ b/data/points/valves/bypass-valve-open.yaml
@@ -26,3 +26,7 @@ aliases:
     - byp-vlv-opn
     - byp vlv op
     - byp-vlv-op
+related:
+  - bypass-valve-closed
+  - bypass-valve-feedback
+  - bypass-valve-output

--- a/data/points/valves/bypass-valve-output.yaml
+++ b/data/points/valves/bypass-valve-output.yaml
@@ -32,4 +32,6 @@ aliases:
     - bypass vlv output
     - bypass-valve-output
 related:
+  - bypass-valve-closed
   - bypass-valve-feedback
+  - bypass-valve-open

--- a/data/points/valves/chilled-water-valve-closed.yaml
+++ b/data/points/valves/chilled-water-valve-closed.yaml
@@ -28,3 +28,5 @@ aliases:
     - chi-vlv-cl
     - chi vlv cld
     - chi-vlv-cld
+related:
+  - chilled-water-valve-open

--- a/data/points/valves/chilled-water-valve-open.yaml
+++ b/data/points/valves/chilled-water-valve-open.yaml
@@ -26,3 +26,5 @@ aliases:
     - chi-vlv-opn
     - chi vlv op
     - chi-vlv-op
+related:
+  - chilled-water-valve-closed

--- a/data/points/valves/condenser-water-valve-closed.yaml
+++ b/data/points/valves/condenser-water-valve-closed.yaml
@@ -28,3 +28,6 @@ aliases:
     - con-vlv-cl
     - con vlv cld
     - con-vlv-cld
+related:
+  - condenser-water-valve-open
+  - cooling-tower-isolation-valve

--- a/data/points/valves/condenser-water-valve-open.yaml
+++ b/data/points/valves/condenser-water-valve-open.yaml
@@ -26,3 +26,6 @@ aliases:
     - con-vlv-opn
     - con vlv op
     - con-vlv-op
+related:
+  - condenser-water-valve-closed
+  - cooling-tower-isolation-valve

--- a/data/points/valves/cooling-tower-isolation-valve.yaml
+++ b/data/points/valves/cooling-tower-isolation-valve.yaml
@@ -63,3 +63,8 @@ aliases:
     - cooling tower isolation vlv
     - cooling-tower-isolation-vlv
     - cooling-tower-isolation-valve
+related:
+  - condenser-water-valve-closed
+  - condenser-water-valve-open
+  - cooling-tower-command
+  - cooling-tower-output

--- a/data/points/valves/cooling-valve-closed.yaml
+++ b/data/points/valves/cooling-valve-closed.yaml
@@ -28,3 +28,7 @@ aliases:
     - coo-vlv-cl
     - coo vlv cld
     - coo-vlv-cld
+related:
+  - cooling-valve-feedback
+  - cooling-valve-open
+  - cooling-valve-output

--- a/data/points/valves/cooling-valve-feedback.yaml
+++ b/data/points/valves/cooling-valve-feedback.yaml
@@ -50,4 +50,6 @@ aliases:
     - clg-valve-feedback
     - cooling-valve-feedback
 related:
+  - cooling-valve-closed
+  - cooling-valve-open
   - cooling-valve-output

--- a/data/points/valves/cooling-valve-open.yaml
+++ b/data/points/valves/cooling-valve-open.yaml
@@ -26,3 +26,7 @@ aliases:
     - coo-vlv-opn
     - coo vlv op
     - coo-vlv-op
+related:
+  - cooling-valve-closed
+  - cooling-valve-feedback
+  - cooling-valve-output

--- a/data/points/valves/cooling-valve-output.yaml
+++ b/data/points/valves/cooling-valve-output.yaml
@@ -57,4 +57,10 @@ aliases:
     - cooling-valve-out
     - cooling-valve-output
 related:
+  - chilled-water-supply-temperature
+  - cooling-enable
+  - cooling-valve-closed
   - cooling-valve-feedback
+  - cooling-valve-open
+  - discharge-air-temperature
+  - zone-temperature

--- a/data/points/valves/heating-valve-closed.yaml
+++ b/data/points/valves/heating-valve-closed.yaml
@@ -28,3 +28,7 @@ aliases:
     - hea-vlv-cl
     - hea vlv cld
     - hea-vlv-cld
+related:
+  - heating-valve-feedback
+  - heating-valve-open
+  - heating-valve-output

--- a/data/points/valves/heating-valve-feedback.yaml
+++ b/data/points/valves/heating-valve-feedback.yaml
@@ -42,4 +42,6 @@ aliases:
     - htg-valve-feedback
     - heating-valve-feedback
 related:
+  - heating-valve-closed
+  - heating-valve-open
   - heating-valve-output

--- a/data/points/valves/heating-valve-open.yaml
+++ b/data/points/valves/heating-valve-open.yaml
@@ -26,3 +26,7 @@ aliases:
     - hea-vlv-opn
     - hea vlv op
     - hea-vlv-op
+related:
+  - heating-valve-closed
+  - heating-valve-feedback
+  - heating-valve-output

--- a/data/points/valves/heating-valve-output.yaml
+++ b/data/points/valves/heating-valve-output.yaml
@@ -48,4 +48,9 @@ aliases:
     - heating-valve-out
     - heating-valve-output
 related:
+  - discharge-air-temperature
+  - heating-enable
+  - heating-valve-closed
   - heating-valve-feedback
+  - heating-valve-open
+  - zone-temperature

--- a/data/points/valves/hot-water-valve-closed.yaml
+++ b/data/points/valves/hot-water-valve-closed.yaml
@@ -28,3 +28,5 @@ aliases:
     - hot-vlv-cl
     - hot vlv cld
     - hot-vlv-cld
+related:
+  - hot-water-valve-open

--- a/data/points/valves/hot-water-valve-open.yaml
+++ b/data/points/valves/hot-water-valve-open.yaml
@@ -26,3 +26,5 @@ aliases:
     - hot-vlv-opn
     - hot vlv op
     - hot-vlv-op
+related:
+  - hot-water-valve-closed

--- a/data/points/valves/isolation-valve-closed.yaml
+++ b/data/points/valves/isolation-valve-closed.yaml
@@ -28,3 +28,7 @@ aliases:
     - iso-vlv-cl
     - iso vlv cld
     - iso-vlv-cld
+related:
+  - isolation-valve-feedback
+  - isolation-valve-open
+  - isolation-valve-output

--- a/data/points/valves/isolation-valve-feedback.yaml
+++ b/data/points/valves/isolation-valve-feedback.yaml
@@ -35,4 +35,6 @@ aliases:
     - isolation-valve-fb
     - isolation-valve-feedback
 related:
+  - isolation-valve-closed
+  - isolation-valve-open
   - isolation-valve-output

--- a/data/points/valves/isolation-valve-open.yaml
+++ b/data/points/valves/isolation-valve-open.yaml
@@ -26,3 +26,7 @@ aliases:
     - iso-vlv-opn
     - iso vlv op
     - iso-vlv-op
+related:
+  - isolation-valve-closed
+  - isolation-valve-feedback
+  - isolation-valve-output

--- a/data/points/valves/isolation-valve-output.yaml
+++ b/data/points/valves/isolation-valve-output.yaml
@@ -31,4 +31,6 @@ aliases:
     - isolation-valve-out
     - isolation-valve-output
 related:
+  - isolation-valve-closed
   - isolation-valve-feedback
+  - isolation-valve-open

--- a/data/points/valves/mixing-valve-closed.yaml
+++ b/data/points/valves/mixing-valve-closed.yaml
@@ -28,3 +28,7 @@ aliases:
     - mix-vlv-cl
     - mix vlv cld
     - mix-vlv-cld
+related:
+  - mixing-valve-feedback
+  - mixing-valve-open
+  - mixing-valve-output

--- a/data/points/valves/mixing-valve-feedback.yaml
+++ b/data/points/valves/mixing-valve-feedback.yaml
@@ -34,4 +34,6 @@ aliases:
     - mix-valve-feedback
     - mixing-valve-feedback
 related:
+  - mixing-valve-closed
+  - mixing-valve-open
   - mixing-valve-output

--- a/data/points/valves/mixing-valve-open.yaml
+++ b/data/points/valves/mixing-valve-open.yaml
@@ -26,3 +26,7 @@ aliases:
     - mix-vlv-opn
     - mix vlv op
     - mix-vlv-op
+related:
+  - mixing-valve-closed
+  - mixing-valve-feedback
+  - mixing-valve-output

--- a/data/points/valves/mixing-valve-output.yaml
+++ b/data/points/valves/mixing-valve-output.yaml
@@ -31,4 +31,6 @@ aliases:
     - mixing-valve-out
     - mixing-valve-output
 related:
+  - mixing-valve-closed
   - mixing-valve-feedback
+  - mixing-valve-open

--- a/data/points/valves/steam-valve-closed.yaml
+++ b/data/points/valves/steam-valve-closed.yaml
@@ -28,3 +28,5 @@ aliases:
     - ste-vlv-cl
     - ste vlv cld
     - ste-vlv-cld
+related:
+  - steam-flow

--- a/data/points/valves/steam-valve-open.yaml
+++ b/data/points/valves/steam-valve-open.yaml
@@ -26,3 +26,5 @@ aliases:
     - ste-vlv-opn
     - ste vlv op
     - ste-vlv-op
+related:
+  - steam-flow

--- a/dist/index.json
+++ b/dist/index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "lastUpdated": "2026-02-23T15:50:46.676Z",
+  "lastUpdated": "2026-02-24T16:01:10.850Z",
   "totalPoints": 259,
   "totalEquipment": 55,
   "points": [
@@ -98,7 +98,13 @@
           "boiler-alarm",
           "boiler warning"
         ]
-      }
+      },
+      "related": [
+        "boiler-command",
+        "boiler-feedback",
+        "boiler-output",
+        "boiler-status"
+      ]
     },
     {
       "concept": {
@@ -195,7 +201,13 @@
           "boiler-pump-alm",
           "boiler-pump-alarm"
         ]
-      }
+      },
+      "related": [
+        "boiler-pump-command",
+        "boiler-pump-feedback",
+        "boiler-pump-output",
+        "boiler-pump-status"
+      ]
     },
     {
       "concept": {
@@ -290,7 +302,13 @@
           "chilled-water-pump-alm",
           "chilled-water-pump-alarm"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-pump-command",
+        "chilled-water-pump-feedback",
+        "chilled-water-pump-output",
+        "chilled-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -397,7 +415,12 @@
           "chiller-alarm",
           "chiller warning"
         ]
-      }
+      },
+      "related": [
+        "chiller-command",
+        "chiller-enable",
+        "chiller-status"
+      ]
     },
     {
       "concept": {
@@ -491,7 +514,13 @@
           "condenser-water-pump-alm",
           "condenser-water-pump-alarm"
         ]
-      }
+      },
+      "related": [
+        "condenser-water-pump-command",
+        "condenser-water-pump-feedback",
+        "condenser-water-pump-output",
+        "condenser-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -602,7 +631,14 @@
           "cooling tower fault",
           "cooling-tower-alarm"
         ]
-      }
+      },
+      "related": [
+        "cooling-tower-command",
+        "cooling-tower-enable",
+        "cooling-tower-feedback",
+        "cooling-tower-output",
+        "cooling-tower-status"
+      ]
     },
     {
       "concept": {
@@ -683,7 +719,8 @@
         ]
       },
       "related": [
-        "filter-differential-pressure"
+        "filter-differential-pressure",
+        "filter-status"
       ]
     },
     {
@@ -770,7 +807,12 @@
           "final-filter-alm",
           "final-filter-alarm"
         ]
-      }
+      },
+      "related": [
+        "filter-differential-pressure",
+        "final-filter-status",
+        "prefilter-alarm"
+      ]
     },
     {
       "concept": {
@@ -932,7 +974,13 @@
           "ht-water-pump-alarm",
           "hot-water-pump-alarm"
         ]
-      }
+      },
+      "related": [
+        "hot-water-pump-command",
+        "hot-water-pump-feedback",
+        "hot-water-pump-output",
+        "hot-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -1021,7 +1069,11 @@
           "low temperature alm",
           "low-temperature-alm"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-temperature",
+        "mixed-air-temperature"
+      ]
     },
     {
       "concept": {
@@ -1105,7 +1157,12 @@
           "prefilter-alarm",
           "pre filter alarm"
         ]
-      }
+      },
+      "related": [
+        "filter-differential-pressure",
+        "final-filter-alarm",
+        "prefilter-status"
+      ]
     },
     {
       "concept": {
@@ -1203,7 +1260,13 @@
           "primary-chilled-water-pump-alm",
           "primary-chilled-water-pump-alarm"
         ]
-      }
+      },
+      "related": [
+        "primary-chilled-water-pump-command",
+        "primary-chilled-water-pump-feedback",
+        "primary-chilled-water-pump-output",
+        "primary-chilled-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -1302,7 +1365,13 @@
           "secondary-chilled-water-pump-alm",
           "secondary-chilled-water-pump-alarm"
         ]
-      }
+      },
+      "related": [
+        "secondary-chilled-water-pump-command",
+        "secondary-chilled-water-pump-feedback",
+        "secondary-chilled-water-pump-output",
+        "secondary-chilled-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -1378,7 +1447,11 @@
           "smoke detect",
           "smoke-detect"
         ]
-      }
+      },
+      "related": [
+        "fire-alarm-status",
+        "smoke-damper-open"
+      ]
     },
     {
       "concept": {
@@ -1476,7 +1549,13 @@
           "boiler-command",
           "boiler start/stop"
         ]
-      }
+      },
+      "related": [
+        "boiler-alarm",
+        "boiler-feedback",
+        "boiler-output",
+        "boiler-status"
+      ]
     },
     {
       "concept": {
@@ -1559,7 +1638,10 @@
         ]
       },
       "related": [
-        "boiler-output"
+        "boiler-alarm",
+        "boiler-command",
+        "boiler-output",
+        "boiler-status"
       ]
     },
     {
@@ -1637,7 +1719,10 @@
         ]
       },
       "related": [
-        "boiler-feedback"
+        "boiler-alarm",
+        "boiler-command",
+        "boiler-feedback",
+        "boiler-status"
       ]
     },
     {
@@ -1731,7 +1816,13 @@
           "blr-pump-command",
           "boiler-pump-command"
         ]
-      }
+      },
+      "related": [
+        "boiler-pump-alarm",
+        "boiler-pump-feedback",
+        "boiler-pump-output",
+        "boiler-pump-status"
+      ]
     },
     {
       "concept": {
@@ -1815,7 +1906,10 @@
         ]
       },
       "related": [
-        "boiler-pump-output"
+        "boiler-pump-alarm",
+        "boiler-pump-command",
+        "boiler-pump-output",
+        "boiler-pump-status"
       ]
     },
     {
@@ -1900,7 +1994,10 @@
         ]
       },
       "related": [
-        "boiler-pump-feedback"
+        "boiler-pump-alarm",
+        "boiler-pump-command",
+        "boiler-pump-feedback",
+        "boiler-pump-status"
       ]
     },
     {
@@ -1992,7 +2089,13 @@
           "chl-water-pump-command",
           "chilled-water-pump-command"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-pump-alarm",
+        "chilled-water-pump-feedback",
+        "chilled-water-pump-output",
+        "chilled-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -2074,7 +2177,10 @@
         ]
       },
       "related": [
-        "chilled-water-pump-output"
+        "chilled-water-pump-alarm",
+        "chilled-water-pump-command",
+        "chilled-water-pump-output",
+        "chilled-water-pump-status"
       ]
     },
     {
@@ -2157,7 +2263,10 @@
         ]
       },
       "related": [
-        "chilled-water-pump-feedback"
+        "chilled-water-pump-alarm",
+        "chilled-water-pump-command",
+        "chilled-water-pump-feedback",
+        "chilled-water-pump-status"
       ]
     },
     {
@@ -2254,7 +2363,12 @@
           "chiller-command",
           "chiller start/stop"
         ]
-      }
+      },
+      "related": [
+        "chiller-alarm",
+        "chiller-enable",
+        "chiller-status"
+      ]
     },
     {
       "concept": {
@@ -2348,7 +2462,12 @@
           "chiller-enable",
           "chiller enabled"
         ]
-      }
+      },
+      "related": [
+        "chiller-alarm",
+        "chiller-command",
+        "chiller-status"
+      ]
     },
     {
       "concept": {
@@ -2438,7 +2557,13 @@
           "condenser-water-pump-cmd",
           "condenser-water-pump-command"
         ]
-      }
+      },
+      "related": [
+        "condenser-water-pump-alarm",
+        "condenser-water-pump-feedback",
+        "condenser-water-pump-output",
+        "condenser-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -2520,7 +2645,10 @@
         ]
       },
       "related": [
-        "condenser-water-pump-output"
+        "condenser-water-pump-alarm",
+        "condenser-water-pump-command",
+        "condenser-water-pump-output",
+        "condenser-water-pump-status"
       ]
     },
     {
@@ -2602,7 +2730,10 @@
         ]
       },
       "related": [
-        "condenser-water-pump-feedback"
+        "condenser-water-pump-alarm",
+        "condenser-water-pump-command",
+        "condenser-water-pump-feedback",
+        "condenser-water-pump-status"
       ]
     },
     {
@@ -2679,7 +2810,13 @@
           "cool enable",
           "cooling-enable"
         ]
-      }
+      },
+      "related": [
+        "cooling-valve-output",
+        "dx-cooling-stage",
+        "heating-enable",
+        "occupied-cooling-setpoint"
+      ]
     },
     {
       "concept": {
@@ -2782,7 +2919,16 @@
           "cooling-tower-command",
           "cooling tower start/stop"
         ]
-      }
+      },
+      "related": [
+        "condenser-water-supply-temperature-setpoint",
+        "cooling-tower-alarm",
+        "cooling-tower-enable",
+        "cooling-tower-feedback",
+        "cooling-tower-isolation-valve",
+        "cooling-tower-output",
+        "cooling-tower-status"
+      ]
     },
     {
       "concept": {
@@ -2879,7 +3025,14 @@
           "cooling-tower-enable",
           "cooling tower enabled"
         ]
-      }
+      },
+      "related": [
+        "cooling-tower-alarm",
+        "cooling-tower-command",
+        "cooling-tower-feedback",
+        "cooling-tower-output",
+        "cooling-tower-status"
+      ]
     },
     {
       "concept": {
@@ -2986,7 +3139,11 @@
         ]
       },
       "related": [
-        "cooling-tower-output"
+        "cooling-tower-alarm",
+        "cooling-tower-command",
+        "cooling-tower-enable",
+        "cooling-tower-output",
+        "cooling-tower-status"
       ]
     },
     {
@@ -3092,7 +3249,12 @@
         ]
       },
       "related": [
-        "cooling-tower-feedback"
+        "cooling-tower-alarm",
+        "cooling-tower-command",
+        "cooling-tower-enable",
+        "cooling-tower-feedback",
+        "cooling-tower-isolation-valve",
+        "cooling-tower-status"
       ]
     },
     {
@@ -3165,7 +3327,11 @@
           "economizer-en",
           "economizer-enable"
         ]
-      }
+      },
+      "related": [
+        "outdoor-air-temperature",
+        "outside-air-damper-output"
+      ]
     },
     {
       "concept": {
@@ -3427,7 +3593,12 @@
           "nrg-recovery-whl-cmd",
           "energy recovery wheel command"
         ]
-      }
+      },
+      "related": [
+        "heat-wheel-feedback",
+        "heat-wheel-output",
+        "heat-wheel-status"
+      ]
     },
     {
       "concept": {
@@ -3515,7 +3686,9 @@
         ]
       },
       "related": [
-        "heat-wheel-output"
+        "heat-wheel-command",
+        "heat-wheel-output",
+        "heat-wheel-status"
       ]
     },
     {
@@ -3602,7 +3775,9 @@
         ]
       },
       "related": [
-        "heat-wheel-feedback"
+        "heat-wheel-command",
+        "heat-wheel-feedback",
+        "heat-wheel-status"
       ]
     },
     {
@@ -3685,7 +3860,13 @@
           "heat enable",
           "heating-enable"
         ]
-      }
+      },
+      "related": [
+        "cooling-enable",
+        "electric-heat-stage",
+        "heating-valve-output",
+        "occupied-heating-setpoint"
+      ]
     },
     {
       "concept": {
@@ -3775,7 +3956,13 @@
           "ht-water-pump-command",
           "hot-water-pump-command"
         ]
-      }
+      },
+      "related": [
+        "hot-water-pump-alarm",
+        "hot-water-pump-feedback",
+        "hot-water-pump-output",
+        "hot-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -3857,7 +4044,10 @@
         ]
       },
       "related": [
-        "hot-water-pump-output"
+        "hot-water-pump-alarm",
+        "hot-water-pump-command",
+        "hot-water-pump-output",
+        "hot-water-pump-status"
       ]
     },
     {
@@ -3939,7 +4129,10 @@
         ]
       },
       "related": [
-        "hot-water-pump-feedback"
+        "hot-water-pump-alarm",
+        "hot-water-pump-command",
+        "hot-water-pump-feedback",
+        "hot-water-pump-status"
       ]
     },
     {
@@ -4012,7 +4205,14 @@
           "occupancy-cmd",
           "occupied-command"
         ]
-      }
+      },
+      "related": [
+        "effective-occupancy",
+        "occupancy",
+        "occupancy-schedule",
+        "system-enable",
+        "unit-enable-mode"
+      ]
     },
     {
       "concept": {
@@ -4106,7 +4306,13 @@
           "primary-chilled-water-pump-cmd",
           "primary-chilled-water-pump-command"
         ]
-      }
+      },
+      "related": [
+        "primary-chilled-water-pump-alarm",
+        "primary-chilled-water-pump-feedback",
+        "primary-chilled-water-pump-output",
+        "primary-chilled-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -4191,7 +4397,10 @@
         ]
       },
       "related": [
-        "primary-chilled-water-pump-output"
+        "primary-chilled-water-pump-alarm",
+        "primary-chilled-water-pump-command",
+        "primary-chilled-water-pump-output",
+        "primary-chilled-water-pump-status"
       ]
     },
     {
@@ -4277,7 +4486,10 @@
         ]
       },
       "related": [
-        "primary-chilled-water-pump-feedback"
+        "primary-chilled-water-pump-alarm",
+        "primary-chilled-water-pump-command",
+        "primary-chilled-water-pump-feedback",
+        "primary-chilled-water-pump-status"
       ]
     },
     {
@@ -4372,7 +4584,13 @@
           "secondary-chilled-water-pump-cmd",
           "secondary-chilled-water-pump-command"
         ]
-      }
+      },
+      "related": [
+        "secondary-chilled-water-pump-alarm",
+        "secondary-chilled-water-pump-feedback",
+        "secondary-chilled-water-pump-output",
+        "secondary-chilled-water-pump-status"
+      ]
     },
     {
       "concept": {
@@ -4457,7 +4675,10 @@
         ]
       },
       "related": [
-        "secondary-chilled-water-pump-output"
+        "secondary-chilled-water-pump-alarm",
+        "secondary-chilled-water-pump-command",
+        "secondary-chilled-water-pump-output",
+        "secondary-chilled-water-pump-status"
       ]
     },
     {
@@ -4543,7 +4764,10 @@
         ]
       },
       "related": [
-        "secondary-chilled-water-pump-feedback"
+        "secondary-chilled-water-pump-alarm",
+        "secondary-chilled-water-pump-command",
+        "secondary-chilled-water-pump-feedback",
+        "secondary-chilled-water-pump-status"
       ]
     },
     {
@@ -4714,6 +4938,7 @@
         ]
       },
       "related": [
+        "steam-flow",
         "steam-heating-feedback"
       ]
     },
@@ -4782,7 +5007,12 @@
           "system-enbl",
           "system-enable"
         ]
-      }
+      },
+      "related": [
+        "occupied-command",
+        "shutdown",
+        "unit-enable-mode"
+      ]
     },
     {
       "concept": {
@@ -4854,7 +5084,11 @@
           "unit enable mode",
           "unit-enable-mode"
         ]
-      }
+      },
+      "related": [
+        "occupied-command",
+        "system-enable"
+      ]
     },
     {
       "concept": {
@@ -4944,7 +5178,13 @@
           "exh-air-damper-closed",
           "exhaust-air-damper-closed"
         ]
-      }
+      },
+      "related": [
+        "exhaust-air-damper-feedback",
+        "exhaust-air-damper-open",
+        "exhaust-air-damper-output",
+        "exhaust-air-damper-position"
+      ]
     },
     {
       "concept": {
@@ -5029,7 +5269,10 @@
         ]
       },
       "related": [
-        "exhaust-air-damper-output"
+        "exhaust-air-damper-closed",
+        "exhaust-air-damper-open",
+        "exhaust-air-damper-output",
+        "exhaust-air-damper-position"
       ]
     },
     {
@@ -5120,7 +5363,13 @@
           "exh-air-damper-open",
           "exhaust-air-damper-open"
         ]
-      }
+      },
+      "related": [
+        "exhaust-air-damper-closed",
+        "exhaust-air-damper-feedback",
+        "exhaust-air-damper-output",
+        "exhaust-air-damper-position"
+      ]
     },
     {
       "concept": {
@@ -5204,7 +5453,12 @@
         ]
       },
       "related": [
-        "exhaust-air-damper-feedback"
+        "building-pressure",
+        "exhaust-air-damper-closed",
+        "exhaust-air-damper-feedback",
+        "exhaust-air-damper-open",
+        "exhaust-air-damper-position",
+        "exhaust-air-flow"
       ]
     },
     {
@@ -5287,7 +5541,13 @@
           "exh-air-damper-position",
           "exhaust-air-damper-position"
         ]
-      }
+      },
+      "related": [
+        "exhaust-air-damper-closed",
+        "exhaust-air-damper-feedback",
+        "exhaust-air-damper-open",
+        "exhaust-air-damper-output"
+      ]
     },
     {
       "concept": {
@@ -5546,7 +5806,13 @@
           "ma-air-damper-closed",
           "mixed-air-damper-closed"
         ]
-      }
+      },
+      "related": [
+        "mixed-air-damper-feedback",
+        "mixed-air-damper-open",
+        "mixed-air-damper-output",
+        "mixed-air-damper-position"
+      ]
     },
     {
       "concept": {
@@ -5631,7 +5897,10 @@
         ]
       },
       "related": [
-        "mixed-air-damper-output"
+        "mixed-air-damper-closed",
+        "mixed-air-damper-open",
+        "mixed-air-damper-output",
+        "mixed-air-damper-position"
       ]
     },
     {
@@ -5722,7 +5991,13 @@
           "ma-air-damper-open",
           "mixed-air-damper-open"
         ]
-      }
+      },
+      "related": [
+        "mixed-air-damper-closed",
+        "mixed-air-damper-feedback",
+        "mixed-air-damper-output",
+        "mixed-air-damper-position"
+      ]
     },
     {
       "concept": {
@@ -5806,7 +6081,10 @@
         ]
       },
       "related": [
-        "mixed-air-damper-feedback"
+        "mixed-air-damper-closed",
+        "mixed-air-damper-feedback",
+        "mixed-air-damper-open",
+        "mixed-air-damper-position"
       ]
     },
     {
@@ -5889,7 +6167,13 @@
           "ma-air-damper-position",
           "mixed-air-damper-position"
         ]
-      }
+      },
+      "related": [
+        "mixed-air-damper-closed",
+        "mixed-air-damper-feedback",
+        "mixed-air-damper-open",
+        "mixed-air-damper-output"
+      ]
     },
     {
       "concept": {
@@ -5980,7 +6264,13 @@
           "outdoor air damper closed",
           "outside-air-damper-closed"
         ]
-      }
+      },
+      "related": [
+        "outside-air-damper-feedback",
+        "outside-air-damper-open",
+        "outside-air-damper-output",
+        "outside-air-damper-position"
+      ]
     },
     {
       "concept": {
@@ -6066,7 +6356,10 @@
         ]
       },
       "related": [
-        "outside-air-damper-output"
+        "outside-air-damper-closed",
+        "outside-air-damper-open",
+        "outside-air-damper-output",
+        "outside-air-damper-position"
       ]
     },
     {
@@ -6158,7 +6451,13 @@
           "outdoor air damper open",
           "outside-air-damper-open"
         ]
-      }
+      },
+      "related": [
+        "outside-air-damper-closed",
+        "outside-air-damper-feedback",
+        "outside-air-damper-output",
+        "outside-air-damper-position"
+      ]
     },
     {
       "concept": {
@@ -6243,7 +6542,14 @@
         ]
       },
       "related": [
-        "outside-air-damper-feedback"
+        "economizer-enable",
+        "minimum-outdoor-airflow-setpoint",
+        "outdoor-air-flow",
+        "outdoor-air-temperature",
+        "outside-air-damper-closed",
+        "outside-air-damper-feedback",
+        "outside-air-damper-open",
+        "outside-air-damper-position"
       ]
     },
     {
@@ -6327,7 +6633,13 @@
           "outdoor air damper position",
           "outside-air-damper-position"
         ]
-      }
+      },
+      "related": [
+        "outside-air-damper-closed",
+        "outside-air-damper-feedback",
+        "outside-air-damper-open",
+        "outside-air-damper-output"
+      ]
     },
     {
       "concept": {
@@ -6416,7 +6728,13 @@
           "rel-air-damper-closed",
           "relief-air-damper-closed"
         ]
-      }
+      },
+      "related": [
+        "relief-air-damper-feedback",
+        "relief-air-damper-open",
+        "relief-air-damper-output",
+        "relief-air-damper-position"
+      ]
     },
     {
       "concept": {
@@ -6500,7 +6818,10 @@
         ]
       },
       "related": [
-        "relief-air-damper-output"
+        "relief-air-damper-closed",
+        "relief-air-damper-open",
+        "relief-air-damper-output",
+        "relief-air-damper-position"
       ]
     },
     {
@@ -6590,7 +6911,13 @@
           "rel-air-damper-open",
           "relief-air-damper-open"
         ]
-      }
+      },
+      "related": [
+        "relief-air-damper-closed",
+        "relief-air-damper-feedback",
+        "relief-air-damper-output",
+        "relief-air-damper-position"
+      ]
     },
     {
       "concept": {
@@ -6674,7 +7001,11 @@
         ]
       },
       "related": [
-        "relief-air-damper-feedback"
+        "building-pressure",
+        "relief-air-damper-closed",
+        "relief-air-damper-feedback",
+        "relief-air-damper-open",
+        "relief-air-damper-position"
       ]
     },
     {
@@ -6757,7 +7088,14 @@
           "rel-air-damper-position",
           "relief-air-damper-position"
         ]
-      }
+      },
+      "related": [
+        "building-pressure-setpoint",
+        "relief-air-damper-closed",
+        "relief-air-damper-feedback",
+        "relief-air-damper-open",
+        "relief-air-damper-output"
+      ]
     },
     {
       "concept": {
@@ -6852,7 +7190,11 @@
           "smoke-damper-open",
           "smoke damper output"
         ]
-      }
+      },
+      "related": [
+        "fire-alarm-status",
+        "smoke-alarm"
+      ]
     },
     {
       "concept": {
@@ -6916,9 +7258,13 @@
         "Used for sizing transformers, generators, and UPS systems"
       ],
       "related": [
+        "electrical-current-sensor",
         "electrical-demand-kw",
+        "energy-consumption-kwh",
+        "frequency-sensor",
+        "power-factor",
         "reactive-power-kvar",
-        "power-factor"
+        "voltage-sensor"
       ]
     },
     {
@@ -6983,9 +7329,13 @@
         "Used with voltage for calculating power (P = V × I × PF)"
       ],
       "related": [
-        "voltage-sensor",
+        "apparent-power-kva",
         "electrical-demand-kw",
-        "power-factor"
+        "energy-consumption-kwh",
+        "frequency-sensor",
+        "power-factor",
+        "reactive-power-kvar",
+        "voltage-sensor"
       ]
     },
     {
@@ -7051,9 +7401,13 @@
         "Typically read from a power meter or CT (current transformer) metering"
       ],
       "related": [
+        "apparent-power-kva",
+        "electrical-current-sensor",
         "energy-consumption-kwh",
+        "frequency-sensor",
         "power-factor",
-        "electrical-current-rms"
+        "reactive-power-kvar",
+        "voltage-sensor"
       ]
     },
     {
@@ -7119,7 +7473,13 @@
         "Often tracked per equipment, floor, or building"
       ],
       "related": [
-        "electrical-demand-kw"
+        "apparent-power-kva",
+        "electrical-current-sensor",
+        "electrical-demand-kw",
+        "frequency-sensor",
+        "power-factor",
+        "reactive-power-kvar",
+        "voltage-sensor"
       ]
     },
     {
@@ -7181,8 +7541,13 @@
         "Critical for generator synchronization and UPS systems"
       ],
       "related": [
-        "voltage-sensor",
-        "electrical-current-sensor"
+        "apparent-power-kva",
+        "electrical-current-sensor",
+        "electrical-demand-kw",
+        "energy-consumption-kwh",
+        "power-factor",
+        "reactive-power-kvar",
+        "voltage-sensor"
       ]
     },
     {
@@ -7243,9 +7608,13 @@
         "Can be improved with capacitor banks or VFDs"
       ],
       "related": [
+        "apparent-power-kva",
+        "electrical-current-sensor",
         "electrical-demand-kw",
+        "energy-consumption-kwh",
+        "frequency-sensor",
         "reactive-power-kvar",
-        "apparent-power-kva"
+        "voltage-sensor"
       ]
     },
     {
@@ -7312,8 +7681,12 @@
       ],
       "related": [
         "apparent-power-kva",
+        "electrical-current-sensor",
+        "electrical-demand-kw",
+        "energy-consumption-kwh",
+        "frequency-sensor",
         "power-factor",
-        "electrical-demand-kw"
+        "voltage-sensor"
       ]
     },
     {
@@ -7377,9 +7750,13 @@
         "Often measured per phase (A, B, C) on three-phase systems"
       ],
       "related": [
+        "apparent-power-kva",
         "electrical-current-sensor",
         "electrical-demand-kw",
-        "frequency-sensor"
+        "energy-consumption-kwh",
+        "frequency-sensor",
+        "power-factor",
+        "reactive-power-kvar"
       ]
     },
     {
@@ -7468,7 +7845,15 @@
           "exhaust-fan-alm",
           "exhaust-fan-alarm"
         ]
-      }
+      },
+      "related": [
+        "exhaust-fan-command",
+        "exhaust-fan-fault",
+        "exhaust-fan-feedback",
+        "exhaust-fan-output",
+        "exhaust-fan-speed",
+        "exhaust-fan-status"
+      ]
     },
     {
       "concept": {
@@ -7551,7 +7936,15 @@
           "exhaust-fan-cmd",
           "exhaust-fan-command"
         ]
-      }
+      },
+      "related": [
+        "exhaust-fan-alarm",
+        "exhaust-fan-fault",
+        "exhaust-fan-feedback",
+        "exhaust-fan-output",
+        "exhaust-fan-speed",
+        "exhaust-fan-status"
+      ]
     },
     {
       "concept": {
@@ -7631,7 +8024,15 @@
           "exh-fan-fault",
           "exhaust-fan-fault"
         ]
-      }
+      },
+      "related": [
+        "exhaust-fan-alarm",
+        "exhaust-fan-command",
+        "exhaust-fan-feedback",
+        "exhaust-fan-output",
+        "exhaust-fan-speed",
+        "exhaust-fan-status"
+      ]
     },
     {
       "concept": {
@@ -7706,7 +8107,12 @@
         ]
       },
       "related": [
-        "exhaust-fan-output"
+        "exhaust-fan-alarm",
+        "exhaust-fan-command",
+        "exhaust-fan-fault",
+        "exhaust-fan-output",
+        "exhaust-fan-speed",
+        "exhaust-fan-status"
       ]
     },
     {
@@ -7781,7 +8187,12 @@
         ]
       },
       "related": [
-        "exhaust-fan-feedback"
+        "exhaust-fan-alarm",
+        "exhaust-fan-command",
+        "exhaust-fan-fault",
+        "exhaust-fan-feedback",
+        "exhaust-fan-speed",
+        "exhaust-fan-status"
       ]
     },
     {
@@ -7858,7 +8269,16 @@
           "exhaust-fan-spd",
           "exhaust-fan-speed"
         ]
-      }
+      },
+      "related": [
+        "exhaust-air-flow",
+        "exhaust-fan-alarm",
+        "exhaust-fan-command",
+        "exhaust-fan-fault",
+        "exhaust-fan-feedback",
+        "exhaust-fan-output",
+        "exhaust-fan-status"
+      ]
     },
     {
       "concept": {
@@ -7945,7 +8365,15 @@
           "exhaust-fan-sts",
           "exhaust-fan-status"
         ]
-      }
+      },
+      "related": [
+        "exhaust-fan-alarm",
+        "exhaust-fan-command",
+        "exhaust-fan-fault",
+        "exhaust-fan-feedback",
+        "exhaust-fan-output",
+        "exhaust-fan-speed"
+      ]
     },
     {
       "concept": {
@@ -8034,7 +8462,15 @@
           "relief-fan-alm",
           "relief-fan-alarm"
         ]
-      }
+      },
+      "related": [
+        "relief-fan-command",
+        "relief-fan-fault",
+        "relief-fan-feedback",
+        "relief-fan-output",
+        "relief-fan-speed",
+        "relief-fan-status"
+      ]
     },
     {
       "concept": {
@@ -8118,7 +8554,15 @@
           "rel-fan-command",
           "relief-fan-command"
         ]
-      }
+      },
+      "related": [
+        "relief-fan-alarm",
+        "relief-fan-fault",
+        "relief-fan-feedback",
+        "relief-fan-output",
+        "relief-fan-speed",
+        "relief-fan-status"
+      ]
     },
     {
       "concept": {
@@ -8198,7 +8642,15 @@
           "rel-fan-fault",
           "relief-fan-fault"
         ]
-      }
+      },
+      "related": [
+        "relief-fan-alarm",
+        "relief-fan-command",
+        "relief-fan-feedback",
+        "relief-fan-output",
+        "relief-fan-speed",
+        "relief-fan-status"
+      ]
     },
     {
       "concept": {
@@ -8273,7 +8725,12 @@
         ]
       },
       "related": [
-        "relief-fan-output"
+        "relief-fan-alarm",
+        "relief-fan-command",
+        "relief-fan-fault",
+        "relief-fan-output",
+        "relief-fan-speed",
+        "relief-fan-status"
       ]
     },
     {
@@ -8349,7 +8806,12 @@
         ]
       },
       "related": [
-        "relief-fan-feedback"
+        "relief-fan-alarm",
+        "relief-fan-command",
+        "relief-fan-fault",
+        "relief-fan-feedback",
+        "relief-fan-speed",
+        "relief-fan-status"
       ]
     },
     {
@@ -8427,7 +8889,15 @@
           "relief-fan-spd",
           "relief-fan-speed"
         ]
-      }
+      },
+      "related": [
+        "relief-fan-alarm",
+        "relief-fan-command",
+        "relief-fan-fault",
+        "relief-fan-feedback",
+        "relief-fan-output",
+        "relief-fan-status"
+      ]
     },
     {
       "concept": {
@@ -8515,7 +8985,15 @@
           "relief-fan-sts",
           "relief-fan-status"
         ]
-      }
+      },
+      "related": [
+        "relief-fan-alarm",
+        "relief-fan-command",
+        "relief-fan-fault",
+        "relief-fan-feedback",
+        "relief-fan-output",
+        "relief-fan-speed"
+      ]
     },
     {
       "concept": {
@@ -8603,7 +9081,15 @@
           "return-fan-alm",
           "return-fan-alarm"
         ]
-      }
+      },
+      "related": [
+        "return-fan-command",
+        "return-fan-fault",
+        "return-fan-feedback",
+        "return-fan-output",
+        "return-fan-speed",
+        "return-fan-status"
+      ]
     },
     {
       "concept": {
@@ -8686,7 +9172,15 @@
           "ret-fan-command",
           "return-fan-command"
         ]
-      }
+      },
+      "related": [
+        "return-fan-alarm",
+        "return-fan-fault",
+        "return-fan-feedback",
+        "return-fan-output",
+        "return-fan-speed",
+        "return-fan-status"
+      ]
     },
     {
       "concept": {
@@ -8766,7 +9260,15 @@
           "ret-fan-fault",
           "return-fan-fault"
         ]
-      }
+      },
+      "related": [
+        "return-fan-alarm",
+        "return-fan-command",
+        "return-fan-feedback",
+        "return-fan-output",
+        "return-fan-speed",
+        "return-fan-status"
+      ]
     },
     {
       "concept": {
@@ -8841,7 +9343,12 @@
         ]
       },
       "related": [
-        "return-fan-output"
+        "return-fan-alarm",
+        "return-fan-command",
+        "return-fan-fault",
+        "return-fan-output",
+        "return-fan-speed",
+        "return-fan-status"
       ]
     },
     {
@@ -8916,7 +9423,12 @@
         ]
       },
       "related": [
-        "return-fan-feedback"
+        "return-fan-alarm",
+        "return-fan-command",
+        "return-fan-fault",
+        "return-fan-feedback",
+        "return-fan-speed",
+        "return-fan-status"
       ]
     },
     {
@@ -8993,7 +9505,15 @@
           "return-fan-spd",
           "return-fan-speed"
         ]
-      }
+      },
+      "related": [
+        "return-fan-alarm",
+        "return-fan-command",
+        "return-fan-fault",
+        "return-fan-feedback",
+        "return-fan-output",
+        "return-fan-status"
+      ]
     },
     {
       "concept": {
@@ -9080,7 +9600,15 @@
           "return-fan-sts",
           "return-fan-status"
         ]
-      }
+      },
+      "related": [
+        "return-fan-alarm",
+        "return-fan-command",
+        "return-fan-fault",
+        "return-fan-feedback",
+        "return-fan-output",
+        "return-fan-speed"
+      ]
     },
     {
       "concept": {
@@ -9176,7 +9704,15 @@
           "supply-fan-alm",
           "supply-fan-alarm"
         ]
-      }
+      },
+      "related": [
+        "supply-fan-command",
+        "supply-fan-fault",
+        "supply-fan-feedback",
+        "supply-fan-output",
+        "supply-fan-speed",
+        "supply-fan-status"
+      ]
     },
     {
       "concept": {
@@ -9267,7 +9803,15 @@
           "sup-fan-command",
           "supply-fan-command"
         ]
-      }
+      },
+      "related": [
+        "supply-fan-alarm",
+        "supply-fan-fault",
+        "supply-fan-feedback",
+        "supply-fan-output",
+        "supply-fan-speed",
+        "supply-fan-status"
+      ]
     },
     {
       "concept": {
@@ -9355,7 +9899,15 @@
           "sup-fan-fault",
           "supply-fan-fault"
         ]
-      }
+      },
+      "related": [
+        "supply-fan-alarm",
+        "supply-fan-command",
+        "supply-fan-feedback",
+        "supply-fan-output",
+        "supply-fan-speed",
+        "supply-fan-status"
+      ]
     },
     {
       "concept": {
@@ -9438,7 +9990,12 @@
         ]
       },
       "related": [
-        "supply-fan-output"
+        "supply-fan-alarm",
+        "supply-fan-command",
+        "supply-fan-fault",
+        "supply-fan-output",
+        "supply-fan-speed",
+        "supply-fan-status"
       ]
     },
     {
@@ -9521,7 +10078,14 @@
         ]
       },
       "related": [
-        "supply-fan-feedback"
+        "discharge-air-pressure",
+        "duct-static-pressure",
+        "supply-fan-alarm",
+        "supply-fan-command",
+        "supply-fan-fault",
+        "supply-fan-feedback",
+        "supply-fan-speed",
+        "supply-fan-status"
       ]
     },
     {
@@ -9608,8 +10172,15 @@
         ]
       },
       "related": [
+        "discharge-air-pressure",
         "duct-static-pressure",
-        "duct-static-pressure-setpoint"
+        "duct-static-pressure-setpoint",
+        "supply-fan-alarm",
+        "supply-fan-command",
+        "supply-fan-fault",
+        "supply-fan-feedback",
+        "supply-fan-output",
+        "supply-fan-status"
       ]
     },
     {
@@ -9727,9 +10298,11 @@
         "Critical for safety interlocks"
       ],
       "related": [
-        "supply-fan-command",
         "supply-fan-alarm",
+        "supply-fan-command",
         "supply-fan-fault",
+        "supply-fan-feedback",
+        "supply-fan-output",
         "supply-fan-speed"
       ]
     },
@@ -9798,9 +10371,10 @@
         "Low flow with high delta-T may indicate valve or pump issues"
       ],
       "related": [
-        "chilled-water-supply-temperature",
+        "chilled-water-differential-pressure",
+        "chilled-water-differential-pressure-setpoint",
         "chilled-water-return-temperature",
-        "chilled-water-differential-pressure"
+        "chilled-water-supply-temperature"
       ]
     },
     {
@@ -9955,7 +10529,10 @@
           "discharge-air-flw",
           "discharge-air-flow"
         ]
-      }
+      },
+      "related": [
+        "supply-air-flow"
+      ]
     },
     {
       "concept": {
@@ -10035,7 +10612,12 @@
           "exhaust-air-flw",
           "exhaust-air-flow"
         ]
-      }
+      },
+      "related": [
+        "exhaust-air-damper-output",
+        "exhaust-fan-speed",
+        "outdoor-air-flow"
+      ]
     },
     {
       "concept": {
@@ -10183,9 +10765,11 @@
         ]
       },
       "related": [
+        "co2-setpoint",
+        "exhaust-air-flow",
         "minimum-outdoor-airflow-setpoint",
-        "zone-co2",
-        "co2-setpoint"
+        "outside-air-damper-output",
+        "zone-co2"
       ]
     },
     {
@@ -10266,7 +10850,11 @@
           "return-air-flw",
           "return-air-flow"
         ]
-      }
+      },
+      "related": [
+        "return-air-temperature",
+        "supply-air-flow"
+      ]
     },
     {
       "concept": {
@@ -10327,6 +10915,7 @@
         "Used for campus steam billing and boiler plant monitoring"
       ],
       "related": [
+        "steam-heating-output",
         "steam-valve-closed",
         "steam-valve-open"
       ]
@@ -10409,7 +10998,11 @@
           "supply-air-flw",
           "supply-air-flow"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-flow",
+        "return-air-flow"
+      ]
     },
     {
       "concept": {
@@ -10495,7 +11088,10 @@
           "discharge-air-hum",
           "discharge-air-humidity"
         ]
-      }
+      },
+      "related": [
+        "dewpoint-temperature"
+      ]
     },
     {
       "concept": {
@@ -10572,7 +11168,13 @@
           "humidifier-en",
           "humidifier-enable"
         ]
-      }
+      },
+      "related": [
+        "humidifier-feedback",
+        "humidifier-output",
+        "humidity-setpoint",
+        "zone-humidity"
+      ]
     },
     {
       "concept": {
@@ -10650,7 +11252,10 @@
         ]
       },
       "related": [
-        "humidifier-output"
+        "humidifier-enable",
+        "humidifier-output",
+        "humidity-setpoint",
+        "zone-humidity"
       ]
     },
     {
@@ -10733,7 +11338,10 @@
         ]
       },
       "related": [
-        "humidifier-feedback"
+        "humidifier-enable",
+        "humidifier-feedback",
+        "humidity-setpoint",
+        "zone-humidity"
       ]
     },
     {
@@ -10820,7 +11428,13 @@
           "outdoor air humid",
           "outdoor-air-humidity"
         ]
-      }
+      },
+      "related": [
+        "outdoor-air-temperature",
+        "return-air-humidity",
+        "wet-bulb-temperature",
+        "zone-humidity"
+      ]
     },
     {
       "concept": {
@@ -10907,7 +11521,12 @@
           "ret-air-humidity",
           "return-air-humidity"
         ]
-      }
+      },
+      "related": [
+        "humidity-setpoint",
+        "outdoor-air-humidity",
+        "zone-humidity"
+      ]
     },
     {
       "concept": {
@@ -10986,7 +11605,13 @@
         ]
       },
       "related": [
-        "humidity-setpoint"
+        "dewpoint-temperature",
+        "humidifier-enable",
+        "humidifier-feedback",
+        "humidifier-output",
+        "humidity-setpoint",
+        "outdoor-air-humidity",
+        "return-air-humidity"
       ]
     },
     {
@@ -11053,9 +11678,11 @@
         "Lower setpoints increase ventilation energy but improve IAQ"
       ],
       "related": [
-        "zone-co2",
+        "minimum-outdoor-airflow-setpoint",
         "outdoor-air-co2",
-        "outdoor-air-flow"
+        "outdoor-air-flow",
+        "return-air-co2",
+        "zone-co2"
       ]
     },
     {
@@ -11185,7 +11812,8 @@
         "Less commonly monitored than PM2.5 in commercial HVAC, but relevant for industrial and healthcare facilities"
       ],
       "related": [
-        "particulate-matter-pm25"
+        "particulate-matter-pm25",
+        "volatile-organic-compounds"
       ]
     },
     {
@@ -11250,7 +11878,7 @@
       ],
       "related": [
         "particulate-matter-pm10",
-        "outdoor-air-quality-index"
+        "volatile-organic-compounds"
       ]
     },
     {
@@ -11314,8 +11942,9 @@
         "Can trigger increased ventilation or filtration when levels are elevated"
       ],
       "related": [
-        "zone-co2",
-        "particulate-matter-pm25"
+        "particulate-matter-pm10",
+        "particulate-matter-pm25",
+        "zone-co2"
       ]
     },
     {
@@ -11388,9 +12017,11 @@
       ],
       "related": [
         "co2-setpoint",
+        "minimum-outdoor-airflow-setpoint",
         "outdoor-air-co2",
         "outdoor-air-flow",
-        "return-air-co2"
+        "return-air-co2",
+        "volatile-organic-compounds"
       ]
     },
     {
@@ -11456,8 +12087,9 @@
         "Used to modulate electric lighting in daylight harvesting sequences"
       ],
       "related": [
+        "lighting-dimming-output",
         "lighting-level",
-        "lighting-dimming-output"
+        "lighting-occupancy-sensor"
       ]
     },
     {
@@ -11655,8 +12287,9 @@
         "Timeout period is configurable (typically 15-30 minutes)"
       ],
       "related": [
-        "lighting-level",
+        "daylight-illuminance",
         "lighting-dimming-output",
+        "lighting-level",
         "occupancy"
       ]
     },
@@ -11854,7 +12487,8 @@
         "High start count relative to run hours indicates a control tuning problem"
       ],
       "related": [
-        "equipment-run-hours"
+        "equipment-run-hours",
+        "run-time"
       ]
     },
     {
@@ -11993,7 +12627,9 @@
         ]
       },
       "related": [
-        "building-pressure-setpoint"
+        "building-pressure-setpoint",
+        "exhaust-air-damper-output",
+        "relief-air-damper-output"
       ]
     },
     {
@@ -12083,7 +12719,12 @@
           "chw-diff",
           "chw-delta-p"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-differential-pressure-setpoint",
+        "chilled-water-flow",
+        "hot-water-differential-pressure"
+      ]
     },
     {
       "concept": {
@@ -12191,7 +12832,11 @@
           "discharge-air-high-pressure-alm",
           "discharge-air-high-pressure-alarm"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-low-pressure-alarm",
+        "discharge-air-pressure"
+      ]
     },
     {
       "concept": {
@@ -12299,7 +12944,11 @@
           "discharge-air-low-pressure-alm",
           "discharge-air-low-pressure-alarm"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-high-pressure-alarm",
+        "discharge-air-pressure"
+      ]
     },
     {
       "concept": {
@@ -12436,10 +13085,13 @@
         "Higher setpoint needed for longer duct runs"
       ],
       "related": [
+        "discharge-air-high-pressure-alarm",
+        "discharge-air-low-pressure-alarm",
         "discharge-air-pressure-setpoint",
-        "supply-fan-speed",
+        "duct-static-pressure",
+        "duct-static-pressure-setpoint",
         "supply-fan-output",
-        "duct-static-pressure-setpoint"
+        "supply-fan-speed"
       ]
     },
     {
@@ -12517,8 +13169,9 @@
       "related": [
         "discharge-air-pressure",
         "discharge-air-pressure-setpoint",
-        "supply-fan-speed",
-        "supply-fan-output"
+        "duct-static-pressure-setpoint",
+        "supply-fan-output",
+        "supply-fan-speed"
       ]
     },
     {
@@ -12590,8 +13243,10 @@
       "related": [
         "filter-alarm",
         "filter-status",
+        "final-filter-alarm",
+        "final-filter-status",
         "prefilter-alarm",
-        "final-filter-alarm"
+        "prefilter-status"
       ]
     },
     {
@@ -12680,7 +13335,11 @@
           "hw-diff",
           "hw-delta-p"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-differential-pressure",
+        "hot-water-flow"
+      ]
     },
     {
       "concept": {
@@ -12785,7 +13444,11 @@
           "return-air-high-pressure-alm",
           "return-air-high-pressure-alarm"
         ]
-      }
+      },
+      "related": [
+        "return-air-low-pressure-alarm",
+        "return-air-pressure"
+      ]
     },
     {
       "concept": {
@@ -12890,7 +13553,11 @@
           "return-air-low-pressure-alm",
           "return-air-low-pressure-alarm"
         ]
-      }
+      },
+      "related": [
+        "return-air-high-pressure-alarm",
+        "return-air-pressure"
+      ]
     },
     {
       "concept": {
@@ -12974,7 +13641,12 @@
           "return-air-press",
           "return-air-pressure"
         ]
-      }
+      },
+      "related": [
+        "return-air-high-pressure-alarm",
+        "return-air-low-pressure-alarm",
+        "return-air-pressure-setpoint"
+      ]
     },
     {
       "concept": {
@@ -13083,7 +13755,10 @@
           "zone pressure",
           "space-pressure"
         ]
-      }
+      },
+      "related": [
+        "building-pressure-setpoint"
+      ]
     },
     {
       "concept": {
@@ -13151,8 +13826,9 @@
       ],
       "related": [
         "building-pressure",
-        "space-pressure",
-        "relief-air-damper-position"
+        "relief-air-damper-position",
+        "return-air-pressure-setpoint",
+        "space-pressure"
       ]
     },
     {
@@ -13477,7 +14153,11 @@
           "clg-outdoor-air-lockout-setpoint",
           "cooling-outdoor-air-lockout-setpoint"
         ]
-      }
+      },
+      "related": [
+        "outdoor-air-temperature",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -13578,7 +14258,12 @@
           "duct-pressure-sp",
           "static-pressure-sp"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-pressure",
+        "duct-static-pressure",
+        "duct-static-pressure-setpoint"
+      ]
     },
     {
       "concept": {
@@ -13656,7 +14341,11 @@
           "dat-setpoint",
           "da-temp-sp"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-temperature",
+        "effective-discharge-air-temperature-setpoint"
+      ]
     },
     {
       "concept": {
@@ -13729,8 +14418,9 @@
         "Static pressure reset can save 20-40% of fan energy"
       ],
       "related": [
-        "duct-static-pressure",
+        "discharge-air-pressure",
         "discharge-air-pressure-setpoint",
+        "duct-static-pressure",
         "supply-fan-speed"
       ]
     },
@@ -13823,7 +14513,13 @@
           "effective-cooling-sp",
           "effective-cooling-setpoint"
         ]
-      }
+      },
+      "related": [
+        "effective-heating-setpoint",
+        "occupied-cooling-setpoint",
+        "standby-cooling-setpoint",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -13916,7 +14612,11 @@
           "effective-discharge-air-temperature-sp",
           "effective-discharge-air-temperature-setpoint"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-temperature",
+        "discharge-air-temperature-setpoint"
+      ]
     },
     {
       "concept": {
@@ -14007,7 +14707,13 @@
           "effective-heating-sp",
           "effective-heating-setpoint"
         ]
-      }
+      },
+      "related": [
+        "effective-cooling-setpoint",
+        "occupied-heating-setpoint",
+        "standby-heating-setpoint",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -14107,7 +14813,10 @@
           "htg-outdoor-air-lockout-setpoint",
           "heating-outdoor-air-lockout-setpoint"
         ]
-      }
+      },
+      "related": [
+        "outdoor-air-temperature"
+      ]
     },
     {
       "concept": {
@@ -14250,9 +14959,12 @@
         "Some systems use separate high-limit and low-limit humidity setpoints"
       ],
       "related": [
-        "zone-humidity",
+        "dewpoint-temperature",
         "humidifier-enable",
-        "humidifier-output"
+        "humidifier-feedback",
+        "humidifier-output",
+        "return-air-humidity",
+        "zone-humidity"
       ]
     },
     {
@@ -14327,9 +15039,10 @@
         "In DCV mode, this setpoint may vary with occupancy count or CO2 levels"
       ],
       "related": [
+        "co2-setpoint",
         "outdoor-air-flow",
-        "zone-co2",
-        "co2-setpoint"
+        "outside-air-damper-output",
+        "zone-co2"
       ]
     },
     {
@@ -14423,7 +15136,10 @@
           "ma-air-temperature-setpoint",
           "mixed-air-temperature-setpoint"
         ]
-      }
+      },
+      "related": [
+        "mixed-air-temperature"
+      ]
     },
     {
       "concept": {
@@ -14532,7 +15248,15 @@
           "occupied-cooling-setpoint",
           "occupied-clg-sp"
         ]
-      }
+      },
+      "related": [
+        "cooling-enable",
+        "effective-cooling-setpoint",
+        "occupied-heating-setpoint",
+        "standby-cooling-setpoint",
+        "unoccupied-cooling-setpoint",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -14641,7 +15365,15 @@
           "occupied-heating-setpoint",
           "occupied-htg-sp"
         ]
-      }
+      },
+      "related": [
+        "effective-heating-setpoint",
+        "heating-enable",
+        "occupied-cooling-setpoint",
+        "standby-heating-setpoint",
+        "unoccupied-heating-setpoint",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -14736,7 +15468,11 @@
           "ret-air-pressure-setpoint",
           "return-air-pressure-setpoint"
         ]
-      }
+      },
+      "related": [
+        "building-pressure-setpoint",
+        "return-air-pressure"
+      ]
     },
     {
       "concept": {
@@ -14834,7 +15570,12 @@
           "stby-cooling-setpoint",
           "standby-cooling-setpoint"
         ]
-      }
+      },
+      "related": [
+        "effective-cooling-setpoint",
+        "occupied-cooling-setpoint",
+        "unoccupied-cooling-setpoint"
+      ]
     },
     {
       "concept": {
@@ -14932,7 +15673,12 @@
           "stby-heating-setpoint",
           "standby-heating-setpoint"
         ]
-      }
+      },
+      "related": [
+        "effective-heating-setpoint",
+        "occupied-heating-setpoint",
+        "unoccupied-heating-setpoint"
+      ]
     },
     {
       "concept": {
@@ -15041,7 +15787,13 @@
           "unoccupied-cooling-setpoint",
           "unoccupied-clg-sp"
         ]
-      }
+      },
+      "related": [
+        "occupied-cooling-setpoint",
+        "standby-cooling-setpoint",
+        "unoccupied-heating-setpoint",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -15150,7 +15902,13 @@
           "unoccupied-heating-setpoint",
           "unoccupied-htg-sp"
         ]
-      }
+      },
+      "related": [
+        "occupied-heating-setpoint",
+        "standby-heating-setpoint",
+        "unoccupied-cooling-setpoint",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -15215,7 +15973,10 @@
           "room-temp-sp",
           "space-temp-sp"
         ]
-      }
+      },
+      "related": [
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -15312,7 +16073,13 @@
           "boiler-pump-sts",
           "boiler-pump-status"
         ]
-      }
+      },
+      "related": [
+        "boiler-pump-alarm",
+        "boiler-pump-command",
+        "boiler-pump-feedback",
+        "boiler-pump-output"
+      ]
     },
     {
       "concept": {
@@ -15417,7 +16184,13 @@
           "boiler running",
           "boiler run status"
         ]
-      }
+      },
+      "related": [
+        "boiler-alarm",
+        "boiler-command",
+        "boiler-feedback",
+        "boiler-output"
+      ]
     },
     {
       "concept": {
@@ -15512,7 +16285,13 @@
           "chilled-water-pump-sts",
           "chilled-water-pump-status"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-pump-alarm",
+        "chilled-water-pump-command",
+        "chilled-water-pump-feedback",
+        "chilled-water-pump-output"
+      ]
     },
     {
       "concept": {
@@ -15623,7 +16402,12 @@
           "chiller running",
           "chiller run status"
         ]
-      }
+      },
+      "related": [
+        "chiller-alarm",
+        "chiller-command",
+        "chiller-enable"
+      ]
     },
     {
       "concept": {
@@ -15717,7 +16501,13 @@
           "condenser-water-pump-sts",
           "condenser-water-pump-status"
         ]
-      }
+      },
+      "related": [
+        "condenser-water-pump-alarm",
+        "condenser-water-pump-command",
+        "condenser-water-pump-feedback",
+        "condenser-water-pump-output"
+      ]
     },
     {
       "concept": {
@@ -15828,7 +16618,14 @@
           "cooling-tower-status",
           "cooling tower running"
         ]
-      }
+      },
+      "related": [
+        "cooling-tower-alarm",
+        "cooling-tower-command",
+        "cooling-tower-enable",
+        "cooling-tower-feedback",
+        "cooling-tower-output"
+      ]
     },
     {
       "concept": {
@@ -15937,7 +16734,12 @@
           "compressor stage",
           "dx-cooling-stage"
         ]
-      }
+      },
+      "related": [
+        "cooling-enable",
+        "discharge-air-temperature",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -16007,7 +16809,12 @@
           "effective-occupancy",
           "current-occupancy"
         ]
-      }
+      },
+      "related": [
+        "occupancy",
+        "occupancy-schedule",
+        "occupied-command"
+      ]
     },
     {
       "concept": {
@@ -16108,7 +16915,12 @@
           "electric-heat-stage",
           "electric heating stage"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-temperature",
+        "heating-enable",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -16186,7 +16998,10 @@
         ]
       },
       "related": [
-        "filter-differential-pressure"
+        "filter-alarm",
+        "filter-differential-pressure",
+        "final-filter-status",
+        "prefilter-status"
       ]
     },
     {
@@ -16270,7 +17085,12 @@
           "fin filter status",
           "final-filter-status"
         ]
-      }
+      },
+      "related": [
+        "filter-differential-pressure",
+        "filter-status",
+        "final-filter-alarm"
+      ]
     },
     {
       "concept": {
@@ -16372,7 +17192,12 @@
           "nrg-recovery-whl-sts",
           "energy recovery wheel status"
         ]
-      }
+      },
+      "related": [
+        "heat-wheel-command",
+        "heat-wheel-feedback",
+        "heat-wheel-output"
+      ]
     },
     {
       "concept": {
@@ -16466,7 +17291,13 @@
           "ht-water-pump-status",
           "hot-water-pump-status"
         ]
-      }
+      },
+      "related": [
+        "hot-water-pump-alarm",
+        "hot-water-pump-command",
+        "hot-water-pump-feedback",
+        "hot-water-pump-output"
+      ]
     },
     {
       "concept": {
@@ -16528,7 +17359,12 @@
           "occupancy schedule",
           "occupancy-schedule"
         ]
-      }
+      },
+      "related": [
+        "effective-occupancy",
+        "occupancy",
+        "occupied-command"
+      ]
     },
     {
       "concept": {
@@ -16582,7 +17418,13 @@
           "occupied",
           "occ"
         ]
-      }
+      },
+      "related": [
+        "effective-occupancy",
+        "lighting-occupancy-sensor",
+        "occupancy-schedule",
+        "occupied-command"
+      ]
     },
     {
       "concept": {
@@ -16663,7 +17505,12 @@
           "prefilter-status",
           "pre filter status"
         ]
-      }
+      },
+      "related": [
+        "filter-differential-pressure",
+        "filter-status",
+        "prefilter-alarm"
+      ]
     },
     {
       "concept": {
@@ -16761,7 +17608,13 @@
           "primary-chilled-water-pump-sts",
           "primary-chilled-water-pump-status"
         ]
-      }
+      },
+      "related": [
+        "primary-chilled-water-pump-alarm",
+        "primary-chilled-water-pump-command",
+        "primary-chilled-water-pump-feedback",
+        "primary-chilled-water-pump-output"
+      ]
     },
     {
       "concept": {
@@ -16854,8 +17707,9 @@
         ]
       },
       "related": [
-        "zone-co2",
-        "co2-setpoint"
+        "co2-setpoint",
+        "outdoor-air-co2",
+        "zone-co2"
       ]
     },
     {
@@ -17016,7 +17870,13 @@
           "secondary-chilled-water-pump-sts",
           "secondary-chilled-water-pump-status"
         ]
-      }
+      },
+      "related": [
+        "secondary-chilled-water-pump-alarm",
+        "secondary-chilled-water-pump-command",
+        "secondary-chilled-water-pump-feedback",
+        "secondary-chilled-water-pump-output"
+      ]
     },
     {
       "concept": {
@@ -17055,7 +17915,10 @@
         "common": [
           "shutdwn"
         ]
-      }
+      },
+      "related": [
+        "system-enable"
+      ]
     },
     {
       "concept": {
@@ -17144,8 +18007,11 @@
         ]
       },
       "related": [
+        "chilled-water-flow",
+        "chilled-water-supply-temperature",
         "chilled-water-supply-temperature-setpoint",
-        "chilled-water-flow"
+        "chiller-entering-temperature",
+        "chiller-leaving-temperature"
       ]
     },
     {
@@ -17251,11 +18117,14 @@
         "Delta T from return typically 10-14°F"
       ],
       "related": [
+        "chilled-water-flow",
         "chilled-water-return-temperature",
-        "chiller-1-leaving-temperature",
-        "cooling-valve-output",
         "chilled-water-supply-temperature-setpoint",
-        "chilled-water-flow"
+        "chiller-entering-temperature",
+        "chiller-leaving-temperature",
+        "cooling-valve-output",
+        "primary-chilled-water-supply-temperature",
+        "secondary-chilled-water-supply-temperature"
       ]
     },
     {
@@ -17384,7 +18253,12 @@
           "chiller entering water temp",
           "chiller-entering-temperature"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-return-temperature",
+        "chilled-water-supply-temperature",
+        "chiller-leaving-temperature"
+      ]
     },
     {
       "concept": {
@@ -17498,7 +18372,12 @@
           "chiller leaving water temp",
           "chiller-leaving-temperature"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-return-temperature",
+        "chilled-water-supply-temperature",
+        "chiller-entering-temperature"
+      ]
     },
     {
       "concept": {
@@ -17569,7 +18448,10 @@
           "city-wtr-temperature",
           "city-water-temperature"
         ]
-      }
+      },
+      "related": [
+        "domestic-hot-water-supply-temperature"
+      ]
     },
     {
       "concept": {
@@ -17657,8 +18539,10 @@
         ]
       },
       "related": [
+        "condenser-water-flow",
+        "condenser-water-supply-temperature",
         "condenser-water-supply-temperature-setpoint",
-        "condenser-water-flow"
+        "cooling-tower-basin-temperature"
       ]
     },
     {
@@ -17747,8 +18631,11 @@
         ]
       },
       "related": [
+        "condenser-water-flow",
+        "condenser-water-return-temperature",
         "condenser-water-supply-temperature-setpoint",
-        "condenser-water-flow"
+        "cooling-tower-basin-temperature",
+        "wet-bulb-temperature"
       ]
     },
     {
@@ -17876,7 +18763,12 @@
           "clg-tower-basin-temperature",
           "cooling-tower-basin-temperature"
         ]
-      }
+      },
+      "related": [
+        "condenser-water-return-temperature",
+        "condenser-water-supply-temperature",
+        "wet-bulb-temperature"
+      ]
     },
     {
       "concept": {
@@ -17946,9 +18838,11 @@
         "Can be calculated from dry bulb temperature and relative humidity"
       ],
       "related": [
-        "zone-humidity",
         "discharge-air-humidity",
-        "humidity-setpoint"
+        "humidity-setpoint",
+        "outdoor-air-temperature",
+        "wet-bulb-temperature",
+        "zone-humidity"
       ]
     },
     {
@@ -18044,11 +18938,17 @@
         "Critical for discharge air temperature control loops"
       ],
       "related": [
-        "supply-air-temperature",
-        "mixed-air-temperature",
-        "discharge-air-temperature-setpoint",
         "cooling-valve-output",
-        "heating-valve-output"
+        "discharge-air-temperature-setpoint",
+        "dx-cooling-stage",
+        "effective-discharge-air-temperature-setpoint",
+        "electric-heat-stage",
+        "heating-valve-output",
+        "low-limit-alarm",
+        "mixed-air-temperature",
+        "return-air-temperature",
+        "supply-air-temperature",
+        "zone-temperature"
       ]
     },
     {
@@ -18135,7 +19035,10 @@
           "domestic-hot-water-return-temp",
           "domestic-hot-water-return-temperature"
         ]
-      }
+      },
+      "related": [
+        "domestic-hot-water-supply-temperature"
+      ]
     },
     {
       "concept": {
@@ -18221,14 +19124,18 @@
           "domestic-hot-water-supply-temp",
           "domestic-hot-water-supply-temperature"
         ]
-      }
+      },
+      "related": [
+        "city-water-temperature",
+        "domestic-hot-water-return-temperature"
+      ]
     },
     {
       "concept": {
-        "id": "exhaust-air-temperaure",
-        "name": "Exhaust Air Temperaure",
+        "id": "exhaust-air-temperature",
+        "name": "Exhaust Air Temperature",
         "category": "temperatures",
-        "description": "Exhaust Air Temperaure point",
+        "description": "Exhaust Air Temperature point",
         "haystack": {
           "tags": [
             {
@@ -18301,9 +19208,13 @@
           "exh-a-temperature",
           "exh air temperaure",
           "exh-air-temperaure",
-          "exhaust-air-temperaure"
+          "exhaust-air-temperaure",
+          "exhaust-air-temperature"
         ]
-      }
+      },
+      "related": [
+        "outdoor-air-temperature"
+      ]
     },
     {
       "concept": {
@@ -18391,8 +19302,9 @@
         ]
       },
       "related": [
-        "hot-water-supply-temperature-setpoint",
-        "hot-water-flow"
+        "hot-water-flow",
+        "hot-water-supply-temperature",
+        "hot-water-supply-temperature-setpoint"
       ]
     },
     {
@@ -18481,8 +19393,11 @@
         ]
       },
       "related": [
+        "hot-water-flow",
+        "hot-water-return-temperature",
         "hot-water-supply-temperature-setpoint",
-        "hot-water-flow"
+        "primary-hot-water-supply-temperature",
+        "secondary-hot-water-supply-temperature"
       ]
     },
     {
@@ -18562,7 +19477,15 @@
           "mixed-air-temperature",
           "mixed-temp"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-temperature",
+        "low-limit-alarm",
+        "mixed-air-temperature-setpoint",
+        "outdoor-air-temperature",
+        "return-air-temperature",
+        "supply-air-temperature"
+      ]
     },
     {
       "concept": {
@@ -18663,10 +19586,15 @@
         "May be provided by weather service in some systems"
       ],
       "related": [
-        "economizer-enable",
         "cooling-outdoor-air-lockout-setpoint",
+        "dewpoint-temperature",
+        "economizer-enable",
+        "exhaust-air-temperature",
         "heating-outdoor-air-lockout-setpoint",
-        "outdoor-air-humidity"
+        "mixed-air-temperature",
+        "outdoor-air-humidity",
+        "outside-air-damper-output",
+        "wet-bulb-temperature"
       ]
     },
     {
@@ -18756,7 +19684,10 @@
           "pri-chilled-water-return-temperature",
           "primary-chilled-water-return-temperature"
         ]
-      }
+      },
+      "related": [
+        "primary-chilled-water-supply-temperature"
+      ]
     },
     {
       "concept": {
@@ -18845,7 +19776,11 @@
           "pri-chilled-water-supply-temperature",
           "primary-chilled-water-supply-temperature"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-supply-temperature",
+        "primary-chilled-water-return-temperature"
+      ]
     },
     {
       "concept": {
@@ -18933,7 +19868,10 @@
           "pri-hot-water-return-temperature",
           "primary-hot-water-return-temperature"
         ]
-      }
+      },
+      "related": [
+        "primary-hot-water-supply-temperature"
+      ]
     },
     {
       "concept": {
@@ -19021,7 +19959,11 @@
           "pri-hot-water-supply-temperature",
           "primary-hot-water-supply-temperature"
         ]
-      }
+      },
+      "related": [
+        "hot-water-supply-temperature",
+        "primary-hot-water-return-temperature"
+      ]
     },
     {
       "concept": {
@@ -19104,7 +20046,14 @@
           "return-air-temperature",
           "return-temp"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-temperature",
+        "mixed-air-temperature",
+        "return-air-flow",
+        "supply-air-temperature",
+        "zone-temperature"
+      ]
     },
     {
       "concept": {
@@ -19193,7 +20142,10 @@
           "sec-chilled-water-return-temperature",
           "secondary-chilled-water-return-temperature"
         ]
-      }
+      },
+      "related": [
+        "secondary-chilled-water-supply-temperature"
+      ]
     },
     {
       "concept": {
@@ -19282,7 +20234,11 @@
           "sec-chilled-water-supply-temperature",
           "secondary-chilled-water-supply-temperature"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-supply-temperature",
+        "secondary-chilled-water-return-temperature"
+      ]
     },
     {
       "concept": {
@@ -19370,7 +20326,10 @@
           "sec-hot-water-return-temperature",
           "secondary-hot-water-return-temperature"
         ]
-      }
+      },
+      "related": [
+        "secondary-hot-water-supply-temperature"
+      ]
     },
     {
       "concept": {
@@ -19458,7 +20417,11 @@
           "sec-hot-water-supply-temperature",
           "secondary-hot-water-supply-temperature"
         ]
-      }
+      },
+      "related": [
+        "hot-water-supply-temperature",
+        "secondary-hot-water-return-temperature"
+      ]
     },
     {
       "concept": {
@@ -19541,7 +20504,12 @@
           "supply-air-temperature",
           "supply-temp"
         ]
-      }
+      },
+      "related": [
+        "discharge-air-temperature",
+        "mixed-air-temperature",
+        "return-air-temperature"
+      ]
     },
     {
       "concept": {
@@ -19610,10 +20578,11 @@
         "Critical for free cooling / waterside economizer calculations"
       ],
       "related": [
-        "outdoor-air-temperature",
-        "outdoor-air-humidity",
+        "condenser-water-supply-temperature",
         "cooling-tower-basin-temperature",
-        "condenser-water-supply-temperature"
+        "dewpoint-temperature",
+        "outdoor-air-humidity",
+        "outdoor-air-temperature"
       ]
     },
     {
@@ -19735,10 +20704,20 @@
         "When multiple sensors in zone, often suffixed ZoneTemp_1, ZoneTemp_Avg"
       ],
       "related": [
+        "cooling-outdoor-air-lockout-setpoint",
+        "cooling-valve-output",
         "discharge-air-temperature",
-        "return-air-temperature",
+        "dx-cooling-stage",
+        "effective-cooling-setpoint",
+        "effective-heating-setpoint",
+        "electric-heat-stage",
+        "heating-valve-output",
         "occupied-cooling-setpoint",
-        "occupied-heating-setpoint"
+        "occupied-heating-setpoint",
+        "return-air-temperature",
+        "unoccupied-cooling-setpoint",
+        "unoccupied-heating-setpoint",
+        "zone-temperature-setpoint"
       ]
     },
     {
@@ -19810,7 +20789,12 @@
           "byp vlv cld",
           "byp-vlv-cld"
         ]
-      }
+      },
+      "related": [
+        "bypass-valve-feedback",
+        "bypass-valve-open",
+        "bypass-valve-output"
+      ]
     },
     {
       "concept": {
@@ -19884,6 +20868,8 @@
         ]
       },
       "related": [
+        "bypass-valve-closed",
+        "bypass-valve-open",
         "bypass-valve-output"
       ]
     },
@@ -19954,7 +20940,12 @@
           "byp vlv op",
           "byp-vlv-op"
         ]
-      }
+      },
+      "related": [
+        "bypass-valve-closed",
+        "bypass-valve-feedback",
+        "bypass-valve-output"
+      ]
     },
     {
       "concept": {
@@ -20024,7 +21015,9 @@
         ]
       },
       "related": [
-        "bypass-valve-feedback"
+        "bypass-valve-closed",
+        "bypass-valve-feedback",
+        "bypass-valve-open"
       ]
     },
     {
@@ -20101,7 +21094,10 @@
           "chi vlv cld",
           "chi-vlv-cld"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-valve-open"
+      ]
     },
     {
       "concept": {
@@ -20175,7 +21171,10 @@
           "chi vlv op",
           "chi-vlv-op"
         ]
-      }
+      },
+      "related": [
+        "chilled-water-valve-closed"
+      ]
     },
     {
       "concept": {
@@ -20251,7 +21250,11 @@
           "con vlv cld",
           "con-vlv-cld"
         ]
-      }
+      },
+      "related": [
+        "condenser-water-valve-open",
+        "cooling-tower-isolation-valve"
+      ]
     },
     {
       "concept": {
@@ -20325,7 +21328,11 @@
           "con vlv op",
           "con-vlv-op"
         ]
-      }
+      },
+      "related": [
+        "condenser-water-valve-closed",
+        "cooling-tower-isolation-valve"
+      ]
     },
     {
       "concept": {
@@ -20428,7 +21435,13 @@
           "cooling-tower-isolation-vlv",
           "cooling-tower-isolation-valve"
         ]
-      }
+      },
+      "related": [
+        "condenser-water-valve-closed",
+        "condenser-water-valve-open",
+        "cooling-tower-command",
+        "cooling-tower-output"
+      ]
     },
     {
       "concept": {
@@ -20499,7 +21512,12 @@
           "coo vlv cld",
           "coo-vlv-cld"
         ]
-      }
+      },
+      "related": [
+        "cooling-valve-feedback",
+        "cooling-valve-open",
+        "cooling-valve-output"
+      ]
     },
     {
       "concept": {
@@ -20587,6 +21605,8 @@
         ]
       },
       "related": [
+        "cooling-valve-closed",
+        "cooling-valve-open",
         "cooling-valve-output"
       ]
     },
@@ -20657,7 +21677,12 @@
           "coo vlv op",
           "coo-vlv-op"
         ]
-      }
+      },
+      "related": [
+        "cooling-valve-closed",
+        "cooling-valve-feedback",
+        "cooling-valve-output"
+      ]
     },
     {
       "concept": {
@@ -20752,7 +21777,13 @@
         ]
       },
       "related": [
-        "cooling-valve-feedback"
+        "chilled-water-supply-temperature",
+        "cooling-enable",
+        "cooling-valve-closed",
+        "cooling-valve-feedback",
+        "cooling-valve-open",
+        "discharge-air-temperature",
+        "zone-temperature"
       ]
     },
     {
@@ -20824,7 +21855,12 @@
           "hea vlv cld",
           "hea-vlv-cld"
         ]
-      }
+      },
+      "related": [
+        "heating-valve-feedback",
+        "heating-valve-open",
+        "heating-valve-output"
+      ]
     },
     {
       "concept": {
@@ -20904,6 +21940,8 @@
         ]
       },
       "related": [
+        "heating-valve-closed",
+        "heating-valve-open",
         "heating-valve-output"
       ]
     },
@@ -20974,7 +22012,12 @@
           "hea vlv op",
           "hea-vlv-op"
         ]
-      }
+      },
+      "related": [
+        "heating-valve-closed",
+        "heating-valve-feedback",
+        "heating-valve-output"
+      ]
     },
     {
       "concept": {
@@ -21060,7 +22103,12 @@
         ]
       },
       "related": [
-        "heating-valve-feedback"
+        "discharge-air-temperature",
+        "heating-enable",
+        "heating-valve-closed",
+        "heating-valve-feedback",
+        "heating-valve-open",
+        "zone-temperature"
       ]
     },
     {
@@ -21137,7 +22185,10 @@
           "hot vlv cld",
           "hot-vlv-cld"
         ]
-      }
+      },
+      "related": [
+        "hot-water-valve-open"
+      ]
     },
     {
       "concept": {
@@ -21211,7 +22262,10 @@
           "hot vlv op",
           "hot-vlv-op"
         ]
-      }
+      },
+      "related": [
+        "hot-water-valve-closed"
+      ]
     },
     {
       "concept": {
@@ -21282,7 +22336,12 @@
           "iso vlv cld",
           "iso-vlv-cld"
         ]
-      }
+      },
+      "related": [
+        "isolation-valve-feedback",
+        "isolation-valve-open",
+        "isolation-valve-output"
+      ]
     },
     {
       "concept": {
@@ -21355,6 +22414,8 @@
         ]
       },
       "related": [
+        "isolation-valve-closed",
+        "isolation-valve-open",
         "isolation-valve-output"
       ]
     },
@@ -21425,7 +22486,12 @@
           "iso vlv op",
           "iso-vlv-op"
         ]
-      }
+      },
+      "related": [
+        "isolation-valve-closed",
+        "isolation-valve-feedback",
+        "isolation-valve-output"
+      ]
     },
     {
       "concept": {
@@ -21494,7 +22560,9 @@
         ]
       },
       "related": [
-        "isolation-valve-feedback"
+        "isolation-valve-closed",
+        "isolation-valve-feedback",
+        "isolation-valve-open"
       ]
     },
     {
@@ -21566,7 +22634,12 @@
           "mix vlv cld",
           "mix-vlv-cld"
         ]
-      }
+      },
+      "related": [
+        "mixing-valve-feedback",
+        "mixing-valve-open",
+        "mixing-valve-output"
+      ]
     },
     {
       "concept": {
@@ -21638,6 +22711,8 @@
         ]
       },
       "related": [
+        "mixing-valve-closed",
+        "mixing-valve-open",
         "mixing-valve-output"
       ]
     },
@@ -21708,7 +22783,12 @@
           "mix vlv op",
           "mix-vlv-op"
         ]
-      }
+      },
+      "related": [
+        "mixing-valve-closed",
+        "mixing-valve-feedback",
+        "mixing-valve-output"
+      ]
     },
     {
       "concept": {
@@ -21777,7 +22857,9 @@
         ]
       },
       "related": [
-        "mixing-valve-feedback"
+        "mixing-valve-closed",
+        "mixing-valve-feedback",
+        "mixing-valve-open"
       ]
     },
     {
@@ -21849,7 +22931,10 @@
           "ste vlv cld",
           "ste-vlv-cld"
         ]
-      }
+      },
+      "related": [
+        "steam-flow"
+      ]
     },
     {
       "concept": {
@@ -21918,7 +23003,10 @@
           "ste vlv op",
           "ste-vlv-op"
         ]
-      }
+      },
+      "related": [
+        "steam-flow"
+      ]
     }
   ],
   "equipment": [
@@ -22003,16 +23091,19 @@
         "supply-air-temperature",
         "return-air-temperature",
         "mixed-air-temperature",
-        "outside-air-temperature",
+        "outdoor-air-temperature",
         "discharge-air-temperature",
         "outside-air-damper-output",
-        "return-air-damper-output",
         "mixed-air-damper-output",
         "cooling-valve-output",
         "heating-valve-output",
         "filter-alarm",
         "low-limit-alarm",
-        "smoke-alarm"
+        "smoke-alarm",
+        "discharge-air-temperature-setpoint",
+        "duct-static-pressure",
+        "duct-static-pressure-setpoint",
+        "filter-differential-pressure"
       ]
     },
     {
@@ -22099,7 +23190,7 @@
         "supply-air-temperature",
         "return-air-temperature",
         "mixed-air-temperature",
-        "outside-air-temperature",
+        "outdoor-air-temperature",
         "discharge-air-temperature",
         "outside-air-damper-output",
         "cooling-valve-output",
@@ -22107,7 +23198,9 @@
         "dx-cooling-stage",
         "gas-fired-heat-output",
         "filter-alarm",
-        "economizer-enable"
+        "economizer-enable",
+        "filter-differential-pressure",
+        "duct-static-pressure"
       ]
     },
     {
@@ -22193,7 +23286,7 @@
         "supply-fan-speed",
         "supply-air-temperature",
         "discharge-air-temperature",
-        "outside-air-temperature",
+        "outdoor-air-temperature",
         "heating-valve-output",
         "gas-fired-heat-output",
         "filter-alarm"
@@ -22266,7 +23359,7 @@
         "supply-fan-status",
         "supply-fan-speed",
         "supply-air-temperature",
-        "outside-air-temperature",
+        "outdoor-air-temperature",
         "discharge-air-temperature",
         "cooling-valve-output",
         "heating-valve-output",
@@ -22363,8 +23456,8 @@
         "zone-temperature",
         "cooling-valve-output",
         "heating-valve-output",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -22678,8 +23771,8 @@
         "supply-fan-status",
         "discharge-air-temperature",
         "zone-temperature",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -22754,8 +23847,8 @@
         "supply-fan-status",
         "discharge-air-temperature",
         "zone-temperature",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -22840,9 +23933,7 @@
         "supply-fan-command",
         "supply-fan-status",
         "discharge-air-temperature",
-        "zone-temperature",
-        "entering-water-temperature",
-        "leaving-water-temperature"
+        "zone-temperature"
       ]
     },
     {
@@ -22929,9 +24020,9 @@
         "supply-fan-status",
         "discharge-air-temperature",
         "zone-temperature",
-        "outside-air-temperature",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "outdoor-air-temperature",
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -23019,7 +24110,7 @@
         "exhaust-fan-status",
         "supply-air-temperature",
         "exhaust-air-temperature",
-        "outside-air-temperature",
+        "outdoor-air-temperature",
         "heat-wheel-output"
       ]
     },
@@ -23095,7 +24186,7 @@
         "exhaust-fan-status",
         "supply-air-temperature",
         "exhaust-air-temperature",
-        "outside-air-temperature"
+        "outdoor-air-temperature"
       ]
     },
     {
@@ -23285,7 +24376,10 @@
         "chiller-status",
         "chiller-alarm",
         "chiller-entering-temperature",
-        "chiller-leaving-temperature"
+        "chiller-leaving-temperature",
+        "chilled-water-supply-temperature",
+        "chilled-water-return-temperature",
+        "chilled-water-flow"
       ]
     },
     {
@@ -23385,7 +24479,10 @@
         "boiler-status",
         "boiler-alarm",
         "hot-water-supply-temperature",
-        "hot-water-return-temperature"
+        "hot-water-return-temperature",
+        "hot-water-flow",
+        "boiler-pump-command",
+        "boiler-pump-status"
       ]
     },
     {
@@ -23469,7 +24566,11 @@
         "cooling-tower-basin-temperature",
         "condenser-water-supply-temperature",
         "condenser-water-return-temperature",
-        "cooling-tower-isolation-valve"
+        "cooling-tower-isolation-valve",
+        "condenser-water-flow",
+        "condenser-water-pump-command",
+        "condenser-water-pump-status",
+        "wet-bulb-temperature"
       ]
     },
     {
@@ -23536,8 +24637,8 @@
         ]
       },
       "typical_points": [
-        "entering-water-temperature",
-        "leaving-water-temperature"
+        "chilled-water-supply-temperature",
+        "chilled-water-return-temperature"
       ]
     },
     {
@@ -23662,7 +24763,8 @@
         "hot-water-pump-output",
         "hot-water-pump-status",
         "hot-water-pump-alarm",
-        "differential-pressure"
+        "chilled-water-differential-pressure",
+        "hot-water-differential-pressure"
       ]
     },
     {
@@ -24357,7 +25459,17 @@
           "electricity meter",
           "electricity-meter"
         ]
-      }
+      },
+      "typical_points": [
+        "energy-consumption-kwh",
+        "electrical-demand-kw",
+        "power-factor",
+        "voltage-sensor",
+        "electrical-current-sensor",
+        "apparent-power-kva",
+        "reactive-power-kvar",
+        "frequency-sensor"
+      ]
     },
     {
       "id": "natural-gas-meter",
@@ -24588,7 +25700,10 @@
           "stm-mass-flw-meter",
           "steam mass flow meter"
         ]
-      }
+      },
+      "typical_points": [
+        "steam-flow"
+      ]
     },
     {
       "id": "btu-meter",
@@ -24960,13 +26075,10 @@
       "typical_points": [
         "zone-temperature",
         "discharge-air-temperature",
-        "damper-position",
-        "damper-output",
-        "airflow",
-        "airflow-setpoint",
+        "supply-air-flow",
         "heating-valve-output",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -25038,8 +26150,8 @@
         "zone-temperature",
         "discharge-air-temperature",
         "heating-valve-output",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -25124,14 +26236,12 @@
       "typical_points": [
         "zone-temperature",
         "discharge-air-temperature",
-        "damper-position",
-        "damper-output",
         "supply-fan-command",
         "supply-fan-status",
-        "airflow",
+        "supply-air-flow",
         "heating-valve-output",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -25206,14 +26316,12 @@
       "typical_points": [
         "zone-temperature",
         "discharge-air-temperature",
-        "damper-position",
-        "damper-output",
         "supply-fan-command",
         "supply-fan-status",
-        "airflow",
+        "supply-air-flow",
         "heating-valve-output",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -25291,7 +26399,7 @@
       "typical_points": [
         "zone-temperature",
         "cooling-valve-output",
-        "cooling-setpoint"
+        "occupied-cooling-setpoint"
       ]
     },
     {
@@ -25364,8 +26472,8 @@
         "zone-temperature",
         "heating-valve-output",
         "cooling-valve-output",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -25438,7 +26546,7 @@
       "typical_points": [
         "zone-temperature",
         "heating-valve-output",
-        "heating-setpoint"
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -25524,7 +26632,7 @@
         "supply-fan-status",
         "heating-valve-output",
         "gas-fired-heat-output",
-        "heating-setpoint"
+        "occupied-heating-setpoint"
       ]
     },
     {
@@ -25835,7 +26943,7 @@
         ]
       },
       "typical_points": [
-        "outside-air-temperature"
+        "outdoor-air-temperature"
       ]
     },
     {
@@ -25946,8 +27054,8 @@
         "discharge-air-temperature",
         "supply-fan-command",
         "supply-fan-status",
-        "cooling-setpoint",
-        "heating-setpoint"
+        "occupied-cooling-setpoint",
+        "occupied-heating-setpoint"
       ]
     },
     {

--- a/dist/search-index.json
+++ b/dist/search-index.json
@@ -9142,15 +9142,15 @@
       ]
     },
     {
-      "id": "exhaust-air-temperaure",
+      "id": "exhaust-air-temperature",
       "type": "point",
-      "name": "Exhaust Air Temperaure",
+      "name": "Exhaust Air Temperature",
       "tokens": [
-        "exhaust air temperaure",
-        "exhaust-air-temperaure",
+        "exhaust air temperature",
+        "exhaust-air-temperature",
         "exhaust",
         "air",
-        "temperaure",
+        "temperature",
         "point",
         "temp",
         "sensor",
@@ -9181,7 +9181,8 @@
         "exh a temperature",
         "exh-a-temperature",
         "exh air temperaure",
-        "exh-air-temperaure"
+        "exh-air-temperaure",
+        "exhaust-air-temperaure"
       ]
     },
     {


### PR DESCRIPTION
Adds `related` fields to all 259 point definitions (previously only 42% had them), making every relationship bidirectional and fixing 3 broken references. Fixes 12 broken `typical_points` references in equipment YAML files by remapping to correct existing point IDs. Enriches `typical_points` for chiller, boiler, cooling-tower, AHU, RTU, heat-exchanger, and pump with missing but logically expected points. Adds `typical_points` to electric-meter and steam-meter, which previously had none. Fixes the long-standing `exhaust-air-temperaure` filename typo by renaming the file and updating all references.